### PR TITLE
docs(ci): link community discussion in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,10 @@ name: publish
 # separate file -> separate workflow_id -> separate concurrency
 # namespace -> none of the stuck-state lives here.
 #
+# See https://github.com/orgs/community/discussions/51410 for the
+# upstream symptom + the "create+merge a PR to nudge repo activity"
+# workaround when a queued workflow_id won't accept cancel/dispatch.
+#
 # How to use:
 #   gh workflow run publish.yml -f tag=v2.17.0
 # or via the Actions UI: "Run workflow" -> enter the version tag.


### PR DESCRIPTION
## Summary
- Adds a reference to https://github.com/orgs/community/discussions/51410 in publish.yml's header comment so the next time we hit the "queued workflow_id refuses cancel/dispatch" failure mode, the context is one click away.

## Secondary purpose
- This PR also serves as the **activity nudge** for the stuck v2.16.1 release run. Per the linked discussion, a merge commit is the cleanest way to push GitHub Actions to recycle a wedged queue state on the repo.

## Test plan
- [ ] Merging this triggers `ci` on main.
- [ ] After merge, `gh workflow run publish.yml -f tag=v2.17.0` returns HTTP 204 and produces a green release run.