### PR TITLE
fix(ui): playlist step row overflowed on narrow (Android) screens

### DIFF
--- a/client/src/screens/Payloads/PlaylistsPanel.tsx
+++ b/client/src/screens/Payloads/PlaylistsPanel.tsx
@@ -595,23 +595,31 @@ function PlaylistCard({
           {playlist.steps.map((step, i) => (
             <li
               key={`${step.path}-${i}`}
-              className={`flex items-center gap-2 rounded border p-2 text-xs ${
+              className={`flex flex-col gap-2 rounded border p-2 text-xs sm:flex-row sm:items-center ${
                 i === activeStepIndex
                   ? "border-[var(--color-accent)] bg-[var(--color-surface-2)]"
                   : "border-[var(--color-border)] bg-[var(--color-surface-2)]"
               }`}
             >
-              <StepStatusIcon
-                index={i}
-                activeIndex={activeStepIndex}
-                isRunning={isThisRunning}
-              />
-              <span className="font-mono text-[11px] text-[var(--color-muted)] tabular-nums">
-                {String(i + 1).padStart(2, "0")}
-              </span>
-              <div className="min-w-0 flex-1 truncate font-mono text-[11px]">
-                {step.path}
+              {/* Status + index + path. On phones this is its own line so
+                  the fixed-width controls below can wrap underneath instead
+                  of pushing the row off-screen. */}
+              <div className="flex min-w-0 items-center gap-2 sm:flex-1">
+                <StepStatusIcon
+                  index={i}
+                  activeIndex={activeStepIndex}
+                  isRunning={isThisRunning}
+                />
+                <span className="shrink-0 font-mono text-[11px] text-[var(--color-muted)] tabular-nums">
+                  {String(i + 1).padStart(2, "0")}
+                </span>
+                <div className="min-w-0 flex-1 truncate font-mono text-[11px]">
+                  {step.path}
+                </div>
               </div>
+              {/* Per-step ip/port/sleep overrides + reorder/remove. Wraps on
+                  narrow viewports; single trailing row on sm+. */}
+              <div className="flex flex-wrap items-center gap-2 sm:flex-nowrap sm:justify-end">
               {/* Per-step IP override. Empty = use the playlist-wide
                   IP entered above. Useful for sequences targeting
                   multiple PS5s (push a loader to dev kit, push
@@ -706,6 +714,7 @@ function PlaylistCard({
                 >
                   <X size={12} />
                 </button>
+              </div>
               </div>
             </li>
           ))}


### PR DESCRIPTION
## Bug
On the Payloads → Playlists panel, a playlist step row ran off the right edge on narrow (Android) viewports.

**Cause:** the row packed the path + fixed-width `ip` (w-28) / `port` (w-16) / `sleep` (w-16) inputs + 3 buttons into one **non-wrapping** flex row. Their combined fixed width exceeds a ~360px phone viewport, so it overflowed horizontally.

## Fix
Mobile-first responsive layout: the status+path is its own line; the per-step controls **wrap** underneath on narrow screens and collapse to a single trailing row at `sm+`. Pure CSS — desktop layout unchanged. Extending the width / horizontal-scrolling would be worse UX on a phone; wrapping is the right call.

## Audit (you asked for a deep, all-component pass)
- Swept **all 23 routes at 360px** in a headless browser: **0 horizontal overflow** on every screen.
- Tables (Hardware/Stats/SmpPanel/AuditLog) are correctly wrapped in `overflow-x-auto` + `min-w`; the Upload ETA table is trivial. No `whitespace-nowrap` on dynamic content. Other input rows already use the correct `flex-1` input + `shrink-0` button pattern.
- This was the lone offender. Applies to **all clients** (responsive CSS; desktop was already fine, narrow/Android now fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)