### PR TITLE
diag(install): log the DPI fallback cascade (#152)

### DIFF
--- a/client/src/state/pkgLibrary.ts
+++ b/client/src/state/pkgLibrary.ts
@@ -767,10 +767,23 @@ async function runDpiInstall(
   onStatus?: (msg: string) => void,
 ): Promise<{ ok: boolean; errMessage: string; daemonFailed: boolean; rc: number }> {
   const ip = hostOf(host);
+  // dpi_ensure sends the DPI ELF to the loader port (:9021), which REPLACES the
+  // running main payload with the clean DPI process. Log around it: this is the
+  // exact moment the main helper is torn down, and issue #152's "helper dies
+  // ~4s after a rejected update" reports land right here — the next bundle will
+  // show whether dpi_ensure succeeded, timed out, or never returned.
+  log.info("install", `DPI ensure: bringing up daemon on ${ip}:9040 (loads via :9021)`);
   const ens = (await invoke("dpi_ensure", { ip })) as {
     ok?: boolean;
     error?: string;
+    listening?: boolean;
+    sent?: boolean;
   };
+  log.info(
+    "install",
+    `DPI ensure result: ok=${ens.ok} listening=${ens.listening ?? "?"} sent=${ens.sent ?? "?"}` +
+      (ens.error ? ` error="${ens.error}"` : ""),
+  );
   if (!ens.ok) {
     return {
       ok: false,
@@ -984,7 +997,24 @@ export async function runPkgInstall(
     // it's safe for patches. HW-proven on the Phat — a Jak X v01.04 patch landed
     // in /user/patch/CUSA07842/patch.pkg with the 3.8 GB base in
     // /user/app/CUSA07842/app.pkg fully intact.
+    // Instrument the whole DPI cascade at info level. Before this, the fallback
+    // ran entirely through busyNotice/onStatus (UI-only, never logged), so a
+    // bug bundle at the default `info` level showed the in-process rejection and
+    // then the payload dying with NO trace of whether DPI was even attempted —
+    // which made the "updates crash the helper" reports (issue #152) impossible
+    // to pin down from logs alone. Now the bundle shows the exact cascade.
+    log.info(
+      "install",
+      `in-process install rejected (${mainErr}) for type=${resolvedType || "?"} — ` +
+        `handing off to DPI daemon (:9040)`,
+    );
     const dpi = await runDpiInstall(host, localPs5Path, onStatus);
+    log.info(
+      "install",
+      `DPI fallback result: ok=${dpi.ok} daemonFailed=${dpi.daemonFailed} ` +
+        `rc=0x${(dpi.rc >>> 0).toString(16).padStart(8, "0")}` +
+        (dpi.errMessage ? ` err="${dpi.errMessage}"` : ""),
+    );
     if (dpi.daemonFailed) {
       // DPI couldn't even come up. For a patch, give update-specific guidance
       // (base is safe; try the PS5's Package Installer) rather than a raw


### PR DESCRIPTION
## Description

Instrumentation for the **#152** "updates kill the helper" crash, from analysing @NotADevBtw's 3.3.24 bug bundle.

The DPI-daemon fallback ran entirely through `busyNotice`/`onStatus` (UI-only, **never logged**), so a bundle at the default `info` level shows the in-process `0x80b21106` rejection and then the payload dying ~4 s later — with **no trace** of whether DPI was attempted, came up, or crashed the helper as it loaded. That gap is why this has been un-diagnosable from logs.

Adds `info`-level logging around the whole cascade (`runPkgInstall` + `runDpiInstall`):
- the in-process → DPI handoff (with the resolved package type),
- `dpi_ensure`'s result — it loads the DPI ELF via **:9021, replacing the running payload**, which is the exact teardown moment the crash coincides with,
- the final DPI verdict (`ok` / `daemonFailed` / `rc` / `err`).

**No behavior change — logging only.**

## Why this and not a code fix

The bundle shows the crash is inside Sony's `sceAppInstUtilInstallByPackage` when it rejects a PS4 patch (this console is **FW 10.40**, not 12.x as the thread assumed) — it returns `0x80b21106` cleanly, then destabilises the payload process ~4 s later. The obvious "skip the in-process attempt for patches" was **already tried and reverted** (`1f12df0` → `ee0832e`: DPI is the path that *lands* patches, and it needs the in-process reject first). A real fix means isolating the InstallByPackage call into a throwaway process — payload work that needs the affected firmware to validate. This PR makes the **next** bundle definitively show where the helper dies.

## Type of Change
- [x] Diagnostics / observability (no behavior change)

## Testing
typecheck + lint + 763 tests + i18n (18 langs) green.

Related to #152 (does not close it — the underlying crash still needs a HW-validated payload fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)