### PR TITLE
ci(docker): publish a ps5upload-engine-webui image alongside the plain engine

### DIFF
--- a/.github/workflows/docker-engine.yml
+++ b/.github/workflows/docker-engine.yml
@@ -1,8 +1,16 @@
 name: docker-engine
 
-# Builds and publishes the ps5upload-engine Docker image to GHCR.
-# Tag pushes (v*) publish a multi-arch (amd64 + arm64) manifest.
-# PRs that touch engine/ get a build-only smoke-check (no push).
+# Builds and publishes two GHCR images from the engine crate:
+#   - ps5upload-engine        (engine/Dockerfile)       — minimal, no UI
+#   - ps5upload-engine-webui  (engine/Dockerfile.webui) — engine + the full
+#     React app served over HTTP, for browser/NAS/headless use (no Tauri
+#     client needed). Its build context is the REPO ROOT, not engine/, since
+#     it needs to `npm ci && npm run build:vite` in client/ before the Rust
+#     build embeds the output.
+#
+# Tag pushes (v*) publish multi-arch (amd64 + arm64) manifests for both
+# images, in lockstep — one release cuts both. PRs that touch engine/ or
+# client/ get a build-only smoke-check of both Dockerfiles (no push).
 #
 # Manual re-run (e.g. after an Actions outage wedges a tag-push run):
 #   gh workflow run docker-engine.yml -f tag=v3.3.16
@@ -10,7 +18,7 @@ on:
   push:
     tags: ['v*']
   pull_request:
-    paths: ['engine/**', '.github/workflows/docker-engine.yml']
+    paths: ['engine/**', 'client/**', '.github/workflows/docker-engine.yml']
   workflow_dispatch:
     inputs:
       tag:
@@ -18,8 +26,9 @@ on:
         required: true
 
 # Least privilege at the top: read-only by default. Only the jobs that actually
-# push to GHCR (build, merge) opt into packages:write below — the PR `verify`
-# job inherits read-only and never gets a write-capable token.
+# push to GHCR (build*, merge*) opt into packages:write below — the PR
+# `verify`/`verify-webui` jobs inherit read-only and never get a write-capable
+# token.
 permissions:
   contents: read
 
@@ -46,10 +55,28 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  # ── PR gate for the webui image: same idea, root context + Dockerfile.webui ─
+  verify-webui:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: engine/Dockerfile.webui
+          platforms: linux/amd64
+          push: false
+          cache-from: type=gha,scope=webui
+          cache-to: type=gha,mode=max,scope=webui
+
   # ── Resolve + validate the tag ONCE, hand the trusted values to build/merge ─
   # Centralizing this means the tag is regex-validated before it ever reaches a
   # checkout `ref:` (no ref injection from a hand-typed workflow_dispatch input),
-  # and the lowercased image name is computed once via the safe env pattern
+  # and the lowercased image names are computed once via the safe env pattern
   # instead of interpolating ${{ github.repository_owner }} into shell.
   resolve:
     if: github.event_name != 'pull_request'
@@ -59,8 +86,9 @@ jobs:
       version: ${{ steps.t.outputs.version }}
       major_minor: ${{ steps.t.outputs.major_minor }}
       image: ${{ steps.t.outputs.image }}
+      image_webui: ${{ steps.t.outputs.image_webui }}
     steps:
-      - name: Validate tag + derive image name
+      - name: Validate tag + derive image names
         id: t
         env:
           INPUT_TAG: ${{ github.event.inputs.tag || github.ref_name }}
@@ -78,6 +106,7 @@ jobs:
             echo "version=$version"
             echo "major_minor=${version%.*}"
             echo "image=ghcr.io/${owner_lc}/ps5upload-engine"
+            echo "image_webui=ghcr.io/${owner_lc}/ps5upload-engine-webui"
           } >> "$GITHUB_OUTPUT"
 
   # ── Per-arch native build, push by digest (no tag yet) ─────────────────────
@@ -145,6 +174,79 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  # ── Per-arch native build of the webui image, push by digest ───────────────
+  # Mirrors `build` above; only the context/file/image/artifact-name/cache-
+  # scope differ. Kept as a separate job (not a matrix dimension on `build`)
+  # so a webui-only failure doesn't need `fail-fast: false` gymnastics to
+  # keep the plain engine image publishing on time.
+  build-webui:
+    needs: resolve
+    if: github.event_name != 'pull_request'
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-24.04,     platform: linux/amd64 }
+          - { os: ubuntu-24.04-arm, platform: linux/arm64 }
+    env:
+      IMAGE: ${{ needs.resolve.outputs.image_webui }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve.outputs.tag }}
+
+      - name: Prepare environment
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: echo "PLATFORM_PAIR=$(printf '%s' "$PLATFORM" | tr '/' '-')" >> "$GITHUB_ENV"
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v6
+        id: meta
+        with:
+          images: ${{ env.IMAGE }}
+
+      - name: Build and push by digest
+        id: push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: engine/Dockerfile.webui
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=webui-${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=webui-${{ env.PLATFORM_PAIR }}
+
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
+        run: |
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}"
+
+      # Distinct "webui-digests-" prefix (not just a "webui-" infix) so the
+      # plain engine `merge` job's `pattern: digests-*` can't glob-match
+      # these artifacts and fold a webui digest into the minimal image's
+      # manifest.
+      - uses: actions/upload-artifact@v7
+        with:
+          name: webui-digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
   # ── Merge per-arch digests into a multi-arch manifest ──────────────────────
   merge:
     needs: [resolve, build]
@@ -189,6 +291,55 @@ jobs:
           # Word-splitting here is intentional: the jq output expands to
           # `-t tagA -t tagB ...` and the printf to space-separated
           # `image@sha256:<digest>` operands, each a distinct argv entry.
+          # shellcheck disable=SC2046
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$META_JSON") \
+            $(printf "${IMAGE}@sha256:%s " *)
+
+      - name: Inspect manifest
+        run: docker buildx imagetools inspect "${IMAGE}:${VERSION}"
+
+  # ── Merge the webui image's per-arch digests ────────────────────────────────
+  merge-webui:
+    needs: [resolve, build-webui]
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    env:
+      IMAGE: ${{ needs.resolve.outputs.image_webui }}
+      VERSION: ${{ needs.resolve.outputs.version }}
+      MAJOR_MINOR: ${{ needs.resolve.outputs.major_minor }}
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          path: /tmp/digests
+          pattern: webui-digests-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v6
+        id: meta
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=raw,value=${{ env.VERSION }}
+            type=raw,value=${{ env.MAJOR_MINOR }}
+            type=raw,value=latest
+
+      - name: Create and push multi-arch manifest
+        working-directory: /tmp/digests
+        env:
+          META_JSON: ${{ steps.meta.outputs.json }}
+        run: |
           # shellcheck disable=SC2046
           docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$META_JSON") \


### PR DESCRIPTION
## Description

The `webui` Cargo feature and `engine/Dockerfile.webui` (merged in #171,
extended in #186) had no CI publish path. `docker-engine.yml` only ever
builds `engine/Dockerfile`, so `ghcr.io/phantomptr/ps5upload-engine`
never gains the browser web UI no matter how many version tags ship it
in the source tree — someone has to build `Dockerfile.webui` by hand
today to get an image with it.

This adds a second published image, `ghcr.io/phantomptr/ps5upload-engine-webui`,
built from `Dockerfile.webui`, published in lockstep with the plain
engine image on every release tag.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [x] CI/build pipeline change

## Changes Made

- `.github/workflows/docker-engine.yml`:
  - New `verify-webui` job — PR-time build-only smoke check of `Dockerfile.webui` (root context), mirroring the existing `verify` job for the plain engine.
  - `resolve` job now also derives `image_webui = ghcr.io/<owner>/ps5upload-engine-webui`.
  - New `build-webui` job — per-arch (amd64+arm64) digest build/push of `Dockerfile.webui`, mirroring `build`. Uses a distinct `webui-digests-` artifact prefix (not just a `webui-` infix) so the plain engine's `merge` job — whose `pattern: digests-*` glob only matches names starting with `digests-` — can't accidentally fold a webui digest into the minimal image's manifest. Uses a separate buildx cache scope (`webui-<platform>`) so the two Dockerfiles don't thrash each other's layer cache.
  - New `merge-webui` job — merges the webui per-arch digests into a multi-arch manifest tagged `<version>`, `<major.minor>`, and `latest`, same scheme as the plain engine.
  - PR trigger paths widened to include `client/**` (previously only `engine/**`), since the webui image's build depends on the frontend, not just the engine crate — a client-only PR can break `Dockerfile.webui`'s build without touching `engine/`.
  - Both images still publish together from a single `v*` tag push or `workflow_dispatch` — one release cuts both.

## Documentation Updates

**Did you update the documentation?** [ ] Yes [x] No

If no documentation updates: this is a CI/publish-pipeline change only — no user-facing behavior changes until the next version tag actually publishes the new image. The self-hosted README section documenting `ghcr.io/phantomptr/ps5upload-engine-webui` usage is still planned as a follow-up alongside capability gating (per #171/#186's "Additional Notes").

## Testing

- [ ] `npm run validate`
- [ ] `npm run coverage`
- [ ] Built PS5 payload successfully
- [ ] Cross-platform CI target checks passed
- [ ] Tested on real PS5 hardware
- [ ] Tested desktop app
- [x] Verified all example commands in docs work — validated the workflow YAML with `python3 -c "import yaml; yaml.safe_load(...)"` and with `actionlint` (downloaded the v1.7.12 release binary locally, since it's not preinstalled here); both clean, including a clean baseline run across all three existing workflow files.
- [x] Tested edge cases and error handling — traced through the artifact-name collision risk explicitly: confirmed `webui-digests-<platform>` does not match the existing `merge` job's `pattern: digests-*` glob (which only matches names starting with `digests-`), so the two merge jobs can't cross-contaminate each other's manifest.

Not tested: an actual live run of this workflow (that requires a real tag push / `workflow_dispatch` on the upstream repo with GHCR push permissions, which I can't do from here). The structure is a mechanical mirror of the existing, already-proven `verify`/`build`/`merge` jobs — same actions, same steps, only `context`/`file`/`image`/artifact-name/cache-scope differ.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation to reflect my changes
- [x] My changes generate no new warnings
- [ ] I have tested my changes on PS5 hardware (or simulated environment)
- [ ] All example code in documentation has been tested and works

## Additional Notes

Once this merges, the webui image will start publishing from the *next* version tag pushed — it won't retroactively backfill `:latest` (or any other tag) from past releases. If you want an image available sooner than the next natural release, `gh workflow run docker-engine.yml -f tag=<existing-tag>` can re-run publishing for an already-tagged version once this workflow change is on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)