### PR TITLE
feat(webui): gate native-only features for the browser client

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,7 +1,8 @@
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, type ReactNode } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
 import AppShell from "./layout/AppShell";
 import { useRosterStore } from "./state/roster";
+import { isTauriEnv } from "./lib/tauriEnv";
 
 /**
  * Code-splitting strategy:
@@ -76,6 +77,15 @@ function LandingRedirect() {
   return <Navigate to={hasConsole ? "/whats-new" : "/connection"} replace />;
 }
 
+/** Guards a route whose screen has NO browser-functional path at all (see
+ *  the matching `hideInBrowser` nav entry in Sidebar.tsx) — redirects a
+ *  direct/typed navigation there in a browser session rather than rendering
+ *  a screen with no working affordances. */
+function NativeOnlyRoute({ children }: { children: ReactNode }) {
+  if (!isTauriEnv()) return <Navigate to="/connection" replace />;
+  return <>{children}</>;
+}
+
 export default function App() {
   return (
     <Routes>
@@ -89,9 +99,11 @@ export default function App() {
         <Route
           path="/upload"
           element={
-            <Suspense fallback={<ScreenLoader />}>
-              <UploadScreen />
-            </Suspense>
+            <NativeOnlyRoute>
+              <Suspense fallback={<ScreenLoader />}>
+                <UploadScreen />
+              </Suspense>
+            </NativeOnlyRoute>
           }
         />
         <Route
@@ -168,9 +180,11 @@ export default function App() {
         <Route
           path="/payloads"
           element={
-            <Suspense fallback={<ScreenLoader />}>
-              <PayloadsScreen />
-            </Suspense>
+            <NativeOnlyRoute>
+              <Suspense fallback={<ScreenLoader />}>
+                <PayloadsScreen />
+              </Suspense>
+            </NativeOnlyRoute>
           }
         />
         <Route

--- a/client/src/components/ErrorBoundary.tsx
+++ b/client/src/components/ErrorBoundary.tsx
@@ -2,6 +2,7 @@ import { Component, type ErrorInfo, type ReactNode } from "react";
 import { log } from "../state/logs";
 import { useLangStore } from "../state/lang";
 import { t as translate } from "../i18n";
+import { isTauriEnv } from "../lib/tauriEnv";
 
 interface Props {
   children: ReactNode;
@@ -132,9 +133,17 @@ export class RootErrorBoundary extends Component<Props, State> {
                   // Package the auto-collected reports and open Discord so the
                   // user can report this crash in one step. Dynamic import
                   // keeps the reporter out of the boundary's static deps.
-                  void import("../lib/reportProblem").then((m) =>
-                    m.reportProblem(`crash-screen: ${err.name}: ${err.message}`),
-                  );
+                  // Browser: there's no host filesystem to zip a report onto
+                  // (crash reports themselves are never written outside
+                  // Tauri — see crashReporter.ts), so just open the channel
+                  // instead of silently failing the zip step.
+                  void import("../lib/reportProblem").then(async (m) => {
+                    if (isTauriEnv()) {
+                      await m.reportProblem(`crash-screen: ${err.name}: ${err.message}`);
+                    } else {
+                      await m.openReportChannel();
+                    }
+                  });
                 }}
                 className="rounded-md border border-[var(--color-accent)] px-3 py-1.5 text-sm font-medium text-[var(--color-accent)] hover:bg-[var(--color-surface)]"
               >

--- a/client/src/layout/AppShell.tsx
+++ b/client/src/layout/AppShell.tsx
@@ -49,7 +49,7 @@ import { installPlayTimeAccumulator } from "../state/playTime";
 import { useTr } from "../state/lang";
 import { isAndroid } from "../lib/platform";
 import { localFs } from "../api/localFs";
-import { getVersion } from "@tauri-apps/api/app";
+import { getAppVersion } from "../lib/appVersion";
 
 /** Background status polling for the engine + payload dots in the
  *  status bar. Runs for the lifetime of the app so the indicators
@@ -115,7 +115,7 @@ function useStatusPolling() {
   // window per host; a genuine later reconnect (past the window) fires again.
   const autoLoaderFiredAtRef = useRef<Record<string, number>>({});
   useEffect(() => {
-    void getVersion()
+    void getAppVersion()
       .then((v) => {
         appVersionRef.current = v;
       })

--- a/client/src/layout/Sidebar.tsx
+++ b/client/src/layout/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { NavLink } from "react-router-dom";
-import { getVersion } from "@tauri-apps/api/app";
+import { getAppVersion } from "../lib/appVersion";
+import { isTauriEnv } from "../lib/tauriEnv";
 import {
   Cable,
   Upload,
@@ -79,6 +80,11 @@ interface NavItem {
    *  {key, fallback} pair so the section label translates alongside
    *  the nav items. */
   section?: { key: string; fallback: string };
+  /** True for screens with no browser-functional path at all (e.g. Upload
+   *  requires a host OS file/folder picker with zero web equivalent) — the
+   *  nav entry is hidden entirely in a browser session rather than linking
+   *  to a screen that can't do anything there. */
+  hideInBrowser?: boolean;
 }
 
 // 2.12.0 sidebar regroup. Previously: 3 sections (Overview / Workflow /
@@ -113,7 +119,17 @@ const items: NavItem[] = [
   // people actually work (orient → connect → send payload → check
   // status) instead of burying it under System as a "manage what's
   // running" tool.
-  { to: "/payloads", key: "payloads", fallback: "Payloads", icon: Boxes },
+  {
+    to: "/payloads",
+    key: "payloads",
+    fallback: "Payloads",
+    icon: Boxes,
+    // Both tabs (Catalog, Send) download/read a payload file on the HOST
+    // filesystem before pushing it to the PS5's loader port — no browser
+    // equivalent. Distinct from Connection's own "send the ps5upload
+    // helper" step (already gated separately), which stays available.
+    hideInBrowser: true,
+  },
   // Dashboard lives with Setup, not System: it's the "am I connected,
   // what's running?" morning check — the thing you look at right after
   // (or instead of) the Connection screen, not a hardware tool.
@@ -131,6 +147,7 @@ const items: NavItem[] = [
     fallback: "Upload",
     icon: Upload,
     section: { key: "nav_section_files", fallback: "Files" },
+    hideInBrowser: true,
   },
   {
     to: "/install-package",
@@ -250,7 +267,7 @@ export default function Sidebar({
   const updateAvailable = useUpdateStore((s) => s.phase.kind === "available");
   const [version, setVersion] = useState<string>("");
   useEffect(() => {
-    getVersion()
+    getAppVersion()
       .then(setVersion)
       .catch(() => setVersion(""));
   }, []);
@@ -286,7 +303,9 @@ export default function Sidebar({
       {/* Navigation — grouped by section. The `section` on the first
           item in a group triggers a small uppercase label above it. */}
       <nav className="min-h-0 flex-1 overflow-y-auto p-2">
-        {items.map(({ to, key, fallback, icon: Icon, section }, idx) => {
+        {items
+          .filter((item) => !item.hideInBrowser || isTauriEnv())
+          .map(({ to, key, fallback, icon: Icon, section }, idx) => {
           const isLogs = to === "/logs";
           const isSettings = to === "/settings";
           return (

--- a/client/src/lib/appVersion.ts
+++ b/client/src/lib/appVersion.ts
@@ -1,0 +1,23 @@
+import { isTauriEnv } from "./tauriEnv";
+import { getEngineUrl } from "../state/engine";
+
+/**
+ * Resolve the running app's version.
+ *
+ * Desktop/Tauri: the app package version (`getVersion()`), which is what
+ * "outdated payload" / About-screen checks care about.
+ *
+ * Browser: there is no separate shell — the engine binary IS the app, so
+ * its own `GET /api/version` is the equivalent. Unwraps the `{version}`
+ * envelope so every call site keeps consuming a plain string either way.
+ */
+export async function getAppVersion(): Promise<string> {
+  if (!isTauriEnv()) {
+    const r = await fetch(`${getEngineUrl()}/api/version`);
+    if (!r.ok) throw new Error(`engine HTTP ${r.status}`);
+    const j = (await r.json()) as { version: string };
+    return j.version;
+  }
+  const { getVersion } = await import("@tauri-apps/api/app");
+  return getVersion();
+}

--- a/client/src/lib/browserDownload.ts
+++ b/client/src/lib/browserDownload.ts
@@ -1,0 +1,23 @@
+/**
+ * Trigger a browser download of in-memory text via a Blob + anchor click.
+ *
+ * Desktop/Tauri callers must NOT use this: the Tauri webview intercepts an
+ * anchor `download` click and routes it through `plugin:fs|write_text_file`,
+ * which the app's capability ACL blocks. That's a Tauri-webview-only quirk —
+ * a real browser has no such interception, so this is the browser-only
+ * counterpart to the native save-dialog path (see e.g.
+ * `screens/Logs/AppLogsPanel.tsx`'s `downloadAll`).
+ */
+export function browserDownloadText(
+  fileName: string,
+  text: string,
+  mimeType = "text/plain",
+): void {
+  const blob = new Blob([text], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = fileName;
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/client/src/lib/windowState.ts
+++ b/client/src/lib/windowState.ts
@@ -5,6 +5,7 @@ import {
   LogicalSize,
 } from "@tauri-apps/api/window";
 import { isMobile } from "./platform";
+import { isTauriEnv } from "./tauriEnv";
 
 /**
  * Persist + restore window size/position across launches. Cross-
@@ -79,7 +80,8 @@ export function useWindowStatePersistence() {
     // size/position to persist, and the desktop-only window APIs below
     // (outerSize/setPosition/onResized…) just throw. Gate inside the
     // effect (not before the hook call) to respect React hooks rules.
-    if (isMobile()) return;
+    // Browser: same window APIs don't exist there either.
+    if (isMobile() || !isTauriEnv()) return;
     let cancelled = false;
     let cleanupResize: (() => void) | null = null;
     let cleanupMove: (() => void) | null = null;

--- a/client/src/screens/About/index.tsx
+++ b/client/src/screens/About/index.tsx
@@ -10,7 +10,7 @@ import {
   Sparkles,
 } from "lucide-react";
 import { openExternalUrl as openExternal } from "../../lib/openExternalUrl";
-import { getVersion } from "@tauri-apps/api/app";
+import { getAppVersion } from "../../lib/appVersion";
 
 import { useTr } from "../../state/lang";
 import { Button, Card } from "../../components";
@@ -80,7 +80,7 @@ export default function AboutScreen() {
   const [version, setVersion] = useState<string>("");
 
   useEffect(() => {
-    getVersion()
+    getAppVersion()
       .then(setVersion)
       .catch(() => setVersion(""));
   }, []);

--- a/client/src/screens/BugReport/index.tsx
+++ b/client/src/screens/BugReport/index.tsx
@@ -26,6 +26,7 @@ import { flushDiskLogNow } from "../../state/logs";
 import { openReportChannel } from "../../lib/reportProblem";
 import type { SavedShot } from "../../lib/captureScreenshot";
 import type { LogLevel } from "../../state/logs";
+import { isTauriEnv } from "../../lib/tauriEnv";
 
 /** Time windows offered for the log slice, in minutes. Mirrors the user's
  *  request: last 1 / 5 / 10 / 30 / 60 / 120 minutes. */
@@ -212,8 +213,8 @@ export default function BugReportScreen() {
       // Make sure the buffered tail of the log is on disk before we window it.
       await flushDiskLogNow();
 
-      const { getVersion } = await import("@tauri-apps/api/app");
-      const appVersion = await getVersion().catch(() => "unknown");
+      const { getAppVersion } = await import("../../lib/appVersion");
+      const appVersion = await getAppVersion().catch(() => "unknown");
 
       const bundle = buildDiagnosticBundle({
         appVersion,
@@ -341,14 +342,16 @@ export default function BugReportScreen() {
                 >
                   {tr("refresh", undefined, "Refresh")}
                 </Button>
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  leftIcon={<ImagePlus size={12} />}
-                  onClick={attachImages}
-                >
-                  {tr("bug_report_images_add", undefined, "Attach file")}
-                </Button>
+                {isTauriEnv() && (
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    leftIcon={<ImagePlus size={12} />}
+                    onClick={attachImages}
+                  >
+                    {tr("bug_report_images_add", undefined, "Attach file")}
+                  </Button>
+                )}
               </div>
             </div>
             <p className="mb-2 flex items-center gap-1 text-xs text-[var(--color-muted)]">
@@ -589,27 +592,37 @@ export default function BugReportScreen() {
             </span>
           </label>
 
-          <div className="mt-4 flex items-center gap-2">
-            <Button
-              variant="primary"
-              leftIcon={
-                busy ? <Loader2 size={14} className="animate-spin" /> : <FileArchive size={14} />
-              }
-              onClick={createReport}
-              disabled={busy}
-            >
-              {busy
-                ? tr("bug_report_building", undefined, "Building…")
-                : tr("bug_report_create", undefined, "Create bug report (.zip)")}
-            </Button>
-            <button
-              type="button"
-              onClick={openLogsFolder}
-              className="text-xs text-[var(--color-accent)] hover:underline"
-            >
-              {tr("logs_open_folder", undefined, "Open logs folder")}
-            </button>
-          </div>
+          {isTauriEnv() ? (
+            <div className="mt-4 flex items-center gap-2">
+              <Button
+                variant="primary"
+                leftIcon={
+                  busy ? <Loader2 size={14} className="animate-spin" /> : <FileArchive size={14} />
+                }
+                onClick={createReport}
+                disabled={busy}
+              >
+                {busy
+                  ? tr("bug_report_building", undefined, "Building…")
+                  : tr("bug_report_create", undefined, "Create bug report (.zip)")}
+              </Button>
+              <button
+                type="button"
+                onClick={openLogsFolder}
+                className="text-xs text-[var(--color-accent)] hover:underline"
+              >
+                {tr("logs_open_folder", undefined, "Open logs folder")}
+              </button>
+            </div>
+          ) : (
+            <p className="mt-4 text-xs text-[var(--color-muted)]">
+              {tr(
+                "bug_report_browser_unsupported",
+                undefined,
+                "Building a bug report zip requires the desktop app — it saves to your computer's filesystem.",
+              )}
+            </p>
+          )}
         </Card>
 
         {/* ── Result / errors span both columns ── */}
@@ -658,14 +671,16 @@ export default function BugReportScreen() {
                 >
                   {tr("bug_report_open_discord", undefined, "Open Discord channel")}
                 </Button>
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  leftIcon={<FolderOpen size={12} />}
-                  onClick={() => void openLogsFolder()}
-                >
-                  {tr("bug_report_open_folder", undefined, "Open logs folder")}
-                </Button>
+                {isTauriEnv() && (
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    leftIcon={<FolderOpen size={12} />}
+                    onClick={() => void openLogsFolder()}
+                  >
+                    {tr("bug_report_open_folder", undefined, "Open logs folder")}
+                  </Button>
+                )}
               </div>
             </Card>
           </div>

--- a/client/src/screens/Connection/index.tsx
+++ b/client/src/screens/Connection/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { getVersion } from "@tauri-apps/api/app";
+import { getAppVersion } from "../../lib/appVersion";
+import { isTauriEnv } from "../../lib/tauriEnv";
 import {
   useConnectionStore,
   PS5_LOADER_PORT,
@@ -620,23 +621,35 @@ export default function ConnectionScreen() {
                 `The PS5Upload helper is a small program your PS5 runs in memory to accept uploads. Sent over port ${PS5_LOADER_PORT}; it takes a few seconds for the PS5 to respond once the bytes arrive.`,
               )}
             </p>
-            <BundledPayloadBanner />
-            <Button
-              variant="primary"
-              size="md"
-              leftIcon={<Send size={14} />}
-              onClick={() => void handleSend()}
-              disabled={step2 === "busy"}
-              loading={step2 === "busy"}
-            >
-              {sendButtonLabel(step2, sendPhase, elapsedMs, tr)}
-            </Button>
-            {step2 === "busy" && (
-              <p className="mt-3 text-xs text-[var(--color-muted)]">
+            {isTauriEnv() ? (
+              <>
+                <BundledPayloadBanner />
+                <Button
+                  variant="primary"
+                  size="md"
+                  leftIcon={<Send size={14} />}
+                  onClick={() => void handleSend()}
+                  disabled={step2 === "busy"}
+                  loading={step2 === "busy"}
+                >
+                  {sendButtonLabel(step2, sendPhase, elapsedMs, tr)}
+                </Button>
+                {step2 === "busy" && (
+                  <p className="mt-3 text-xs text-[var(--color-muted)]">
+                    {tr(
+                      "connection_step2_busy_hint",
+                      undefined,
+                      "The PS5 typically boots the helper within 3-5 seconds. We keep polling for up to 20 seconds before giving up — if it times out, send it again.",
+                    )}
+                  </p>
+                )}
+              </>
+            ) : (
+              <p className="text-xs text-[var(--color-muted)]">
                 {tr(
-                  "connection_step2_busy_hint",
+                  "connection_step2_browser_unsupported",
                   undefined,
-                  "The PS5 typically boots the helper within 3-5 seconds. We keep polling for up to 20 seconds before giving up — if it times out, send it again.",
+                  "The browser can't read a local helper file to send. Load the helper from the desktop app or a USB autoloader first, then this page will detect it automatically.",
                 )}
               </p>
             )}
@@ -1250,7 +1263,7 @@ function VersionBlock({ onResend }: { onResend?: () => void }) {
   // construction.
   const [appVersion, setAppVersion] = useState<string | null>(null);
   useEffect(() => {
-    getVersion()
+    getAppVersion()
       .then(setAppVersion)
       .catch((e) => {
         // Without an app version we can't compare against the
@@ -1442,7 +1455,7 @@ function VersionBlock({ onResend }: { onResend?: () => void }) {
               )}
             </p>
           </div>
-          {onResend && (
+          {onResend && isTauriEnv() && (
             <Button
               variant="secondary"
               size="sm"

--- a/client/src/screens/FileSystem/index.tsx
+++ b/client/src/screens/FileSystem/index.tsx
@@ -28,6 +28,7 @@ import {
 } from "lucide-react";
 import { pickPath } from "../../lib/pickPath";
 import { save as saveDialog } from "@tauri-apps/plugin-dialog";
+import { isTauriEnv } from "../../lib/tauriEnv";
 import { PageHeader, Button, ConnectionGate } from "../../components";
 // Direct import to avoid the barrel's circular-dep warning at build.
 import {
@@ -2154,39 +2155,43 @@ export default function FileSystemScreen() {
                   {isDir ? "—" : formatBytes(e.size)}
                 </span>
                 <div className="ml-2 flex shrink-0 items-center gap-1">
-                  <button
-                    type="button"
-                    onClick={() => runDownload(e)}
-                    disabled={downloadOp.active}
-                    title={tr(
-                      "fs_download_tooltip",
-                      undefined,
-                      "Save a copy of this entry to a folder on this computer",
-                    )}
-                    className="rounded-md border border-[var(--color-border)] p-1 hover:bg-[var(--color-surface-3)] disabled:opacity-30"
-                  >
-                    {downloadHere && downloadOp.rootName === e.name ? (
-                      <Loader2
-                        size={12}
-                        className="animate-spin text-[var(--color-accent)]"
-                      />
-                    ) : (
-                      <Download size={12} />
-                    )}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => runDownload(e, true)}
-                    disabled={downloadOp.active}
-                    title={tr(
-                      "fs_download_zip_tooltip",
-                      undefined,
-                      "Download to this computer as a .zip (streamed — no temp copy)",
-                    )}
-                    className="rounded-md border border-[var(--color-border)] p-1 hover:bg-[var(--color-surface-3)] disabled:opacity-30"
-                  >
-                    <FileArchive size={12} />
-                  </button>
+                  {isTauriEnv() && (
+                    <>
+                      <button
+                        type="button"
+                        onClick={() => runDownload(e)}
+                        disabled={downloadOp.active}
+                        title={tr(
+                          "fs_download_tooltip",
+                          undefined,
+                          "Save a copy of this entry to a folder on this computer",
+                        )}
+                        className="rounded-md border border-[var(--color-border)] p-1 hover:bg-[var(--color-surface-3)] disabled:opacity-30"
+                      >
+                        {downloadHere && downloadOp.rootName === e.name ? (
+                          <Loader2
+                            size={12}
+                            className="animate-spin text-[var(--color-accent)]"
+                          />
+                        ) : (
+                          <Download size={12} />
+                        )}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => runDownload(e, true)}
+                        disabled={downloadOp.active}
+                        title={tr(
+                          "fs_download_zip_tooltip",
+                          undefined,
+                          "Download to this computer as a .zip (streamed — no temp copy)",
+                        )}
+                        className="rounded-md border border-[var(--color-border)] p-1 hover:bg-[var(--color-surface-3)] disabled:opacity-30"
+                      >
+                        <FileArchive size={12} />
+                      </button>
+                    </>
+                  )}
                   <button
                     type="button"
                     onClick={() => {

--- a/client/src/screens/InstallPackage/index.tsx
+++ b/client/src/screens/InstallPackage/index.tsx
@@ -691,64 +691,68 @@ export default function InstallPackageScreen() {
                 {tr("pkglib.installAll", undefined, "Install all")} ({installableCount})
               </Button>
             )}
-            <Button
-              variant="primary"
-              size="sm"
-              leftIcon={<Plus size={14} />}
-              onClick={handlePick}
-              loading={picking}
-              disabled={!hostReady || installing || installingAll}
-              title={
-                !hostReady
-                  ? tr(
-                      "install.add.disabledHint",
-                      "Set a PS5 host on the Connection tab first",
+            {isTauriEnv() && (
+              <>
+                <Button
+                  variant="primary"
+                  size="sm"
+                  leftIcon={<Plus size={14} />}
+                  onClick={handlePick}
+                  loading={picking}
+                  disabled={!hostReady || installing || installingAll}
+                  title={
+                    !hostReady
+                      ? tr(
+                          "install.add.disabledHint",
+                          "Set a PS5 host on the Connection tab first",
+                        )
+                      : installing
+                        ? tr(
+                            "pkglib.add.installingHint",
+                            "Wait for the current install to finish",
+                          )
+                        : undefined
+                  }
+                >
+                  {tr("install.add", "Add .pkg")}
+                </Button>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  leftIcon={
+                    streaming ? (
+                      <Loader2 size={14} className="animate-spin" />
+                    ) : (
+                      <Download size={14} />
                     )
-                  : installing
-                    ? tr(
-                        "pkglib.add.installingHint",
-                        "Wait for the current install to finish",
-                      )
-                    : undefined
-              }
-            >
-              {tr("install.add", "Add .pkg")}
-            </Button>
-            <Button
-              variant="secondary"
-              size="sm"
-              leftIcon={
-                streaming ? (
-                  <Loader2 size={14} className="animate-spin" />
-                ) : (
-                  <Download size={14} />
-                )
-              }
-              onClick={handleStreamPick}
-              loading={streaming}
-              disabled={
-                !hostReady || installing || installingAll || streamBlocked
-              }
-              title={
-                !hostReady
-                  ? tr(
-                      "install.add.disabledHint",
-                      "Set a PS5 host on the Connection tab first",
-                    )
-                  : streamBlocked
-                    ? tr(
-                        "pkglib.stream.fwLow.hint",
-                        { fw: String(fwMajor) },
-                        `Stream install needs firmware 11+ — yours is ${fwMajor}.x. The HTTP path hangs on older firmware. Use Upload → Install (staged) instead.`,
-                      )
-                    : tr(
-                        "pkglib.stream.hint",
-                        "Install a .pkg straight from this PC over HTTP — no staging upload (beta)",
-                      )
-              }
-            >
-              {tr("pkglib.stream", undefined, "Stream (beta)")}
-            </Button>
+                  }
+                  onClick={handleStreamPick}
+                  loading={streaming}
+                  disabled={
+                    !hostReady || installing || installingAll || streamBlocked
+                  }
+                  title={
+                    !hostReady
+                      ? tr(
+                          "install.add.disabledHint",
+                          "Set a PS5 host on the Connection tab first",
+                        )
+                      : streamBlocked
+                        ? tr(
+                            "pkglib.stream.fwLow.hint",
+                            { fw: String(fwMajor) },
+                            `Stream install needs firmware 11+ — yours is ${fwMajor}.x. The HTTP path hangs on older firmware. Use Upload → Install (staged) instead.`,
+                          )
+                        : tr(
+                            "pkglib.stream.hint",
+                            "Install a .pkg straight from this PC over HTTP — no staging upload (beta)",
+                          )
+                  }
+                >
+                  {tr("pkglib.stream", undefined, "Stream (beta)")}
+                </Button>
+              </>
+            )}
           </div>
         }
       />

--- a/client/src/screens/Logs/AppLogsPanel.tsx
+++ b/client/src/screens/Logs/AppLogsPanel.tsx
@@ -19,6 +19,8 @@ import { useDiagSettingsStore, LOG_LEVELS } from "../../state/diagSettings";
 import { EmptyState, Button } from "../../components";
 import { useTr } from "../../state/lang";
 import { writeClipboard } from "../../lib/clipboard";
+import { isTauriEnv } from "../../lib/tauriEnv";
+import { browserDownloadText } from "../../lib/browserDownload";
 
 const LEVEL_ORDER: LogLevel[] = ["error", "warn", "info", "debug", "trace"];
 
@@ -122,18 +124,27 @@ export default function AppLogsPanel() {
           }`,
       )
       .join("\n");
-    // Save via the native dialog + backend `save_text_file` command rather
-    // than a Blob/anchor `download`. In the Tauri webview an anchor download
-    // is routed to `plugin:fs|write_text_file`, which the capability ACL
-    // blocks ("Command plugin:fs|write_text_file not allowed by ACL") — the
-    // exact error users hit trying to save logs. The backend command writes
-    // from trusted Rust and isn't fs-scope-gated. Mirrors Stats/Settings.
+    const fileName = `ps5upload-logs-${new Date()
+      .toISOString()
+      .replace(/[:.]/g, "-")}.txt`;
     try {
+      if (!isTauriEnv()) {
+        // Plain Blob + anchor download — safe here since the Tauri-webview
+        // ACL interception (see the native branch below) doesn't apply in a
+        // real browser.
+        browserDownloadText(fileName, text);
+        setSaveState("done");
+        setTimeout(() => setSaveState("idle"), 1600);
+        return;
+      }
+      // Save via the native dialog + backend `save_text_file` command rather
+      // than a Blob/anchor `download`. In the Tauri webview an anchor download
+      // is routed to `plugin:fs|write_text_file`, which the capability ACL
+      // blocks ("Command plugin:fs|write_text_file not allowed by ACL") — the
+      // exact error users hit trying to save logs. The backend command writes
+      // from trusted Rust and isn't fs-scope-gated. Mirrors Stats/Settings.
       const { save } = await import("@tauri-apps/plugin-dialog");
       const { writeTextFileToPath } = await import("../../lib/saveTextFile");
-      const fileName = `ps5upload-logs-${new Date()
-        .toISOString()
-        .replace(/[:.]/g, "-")}.txt`;
       const dest = await save({
         defaultPath: fileName,
         filters: [{ name: "Text", extensions: ["txt"] }],
@@ -222,13 +233,15 @@ export default function AppLogsPanel() {
             </option>
           ))}
         </select>
-        <button
-          type="button"
-          onClick={() => void invoke("diag_log_open_dir").catch(() => {})}
-          className="ml-auto text-[var(--color-accent)] hover:underline"
-        >
-          {tr("logs_open_folder", undefined, "Open logs folder")}
-        </button>
+        {isTauriEnv() && (
+          <button
+            type="button"
+            onClick={() => void invoke("diag_log_open_dir").catch(() => {})}
+            className="ml-auto text-[var(--color-accent)] hover:underline"
+          >
+            {tr("logs_open_folder", undefined, "Open logs folder")}
+          </button>
+        )}
       </div>
 
       <div className="mb-4 flex flex-wrap items-center gap-1.5 text-xs">

--- a/client/src/screens/Profile/index.tsx
+++ b/client/src/screens/Profile/index.tsx
@@ -23,6 +23,7 @@ import {
 import { useTr } from "../../state/lang";
 import { useConnectionStore } from "../../state/connection";
 import { mgmtAddr } from "../../lib/addr";
+import { isTauriEnv } from "../../lib/tauriEnv";
 import {
   profileInfo,
   profileApplyAvatar,
@@ -294,9 +295,11 @@ function AvatarSection({
         {/* Controls */}
         <div className="flex min-w-0 flex-1 flex-col gap-3">
           <div className="flex flex-wrap items-center gap-2">
-            <Button variant="secondary" size="sm" onClick={pickImage}>
-              {tr("profile.avatar.pick", "Choose image…")}
-            </Button>
+            {isTauriEnv() && (
+              <Button variant="secondary" size="sm" onClick={pickImage}>
+                {tr("profile.avatar.pick", "Choose image…")}
+              </Button>
+            )}
             {fileName && (
               <span className="truncate text-xs text-[var(--color-muted)]">
                 {fileName}

--- a/client/src/screens/Saves/index.tsx
+++ b/client/src/screens/Saves/index.tsx
@@ -51,6 +51,7 @@ import { save as saveDialog } from "@tauri-apps/plugin-dialog";
 import { pickPath } from "../../lib/pickPath";
 import { pushNotification } from "../../state/notifications";
 import { withConsolePrefix } from "../../state/roster";
+import { isTauriEnv } from "../../lib/tauriEnv";
 
 /**
  * Save data manager.
@@ -752,52 +753,56 @@ export default function SavesScreen() {
         )}
         right={
           <div className="flex items-center gap-2">
-            <Button
-              variant="secondary"
-              size="sm"
-              leftIcon={
-                bulkBackupBusy ? (
-                  <Loader2 size={12} className="animate-spin" />
-                ) : (
-                  <HardDrive size={12} />
-                )
-              }
-              onClick={handleBackupAllToUsb}
-              disabled={
-                bulkBackupBusy ||
-                bulkRestoreBusy ||
-                loading ||
-                !host?.trim() ||
-                payloadStatus !== "up" ||
-                !saves ||
-                saves.length === 0
-              }
-            >
-              {tr("saves_backup_usb_all", undefined, "Back up all to USB")}
-            </Button>
-            <Button
-              variant="secondary"
-              size="sm"
-              leftIcon={
-                bulkRestoreBusy ? (
-                  <Loader2 size={12} className="animate-spin" />
-                ) : (
-                  <UploadIcon size={12} />
-                )
-              }
-              onClick={handleRestoreAllFromUsb}
-              disabled={
-                bulkRestoreBusy ||
-                bulkBackupBusy ||
-                loading ||
-                !host?.trim() ||
-                payloadStatus !== "up" ||
-                !saves ||
-                saves.length === 0
-              }
-            >
-              {tr("saves_restore_usb_all", undefined, "Restore all from USB")}
-            </Button>
+            {isTauriEnv() && (
+              <>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  leftIcon={
+                    bulkBackupBusy ? (
+                      <Loader2 size={12} className="animate-spin" />
+                    ) : (
+                      <HardDrive size={12} />
+                    )
+                  }
+                  onClick={handleBackupAllToUsb}
+                  disabled={
+                    bulkBackupBusy ||
+                    bulkRestoreBusy ||
+                    loading ||
+                    !host?.trim() ||
+                    payloadStatus !== "up" ||
+                    !saves ||
+                    saves.length === 0
+                  }
+                >
+                  {tr("saves_backup_usb_all", undefined, "Back up all to USB")}
+                </Button>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  leftIcon={
+                    bulkRestoreBusy ? (
+                      <Loader2 size={12} className="animate-spin" />
+                    ) : (
+                      <UploadIcon size={12} />
+                    )
+                  }
+                  onClick={handleRestoreAllFromUsb}
+                  disabled={
+                    bulkRestoreBusy ||
+                    bulkBackupBusy ||
+                    loading ||
+                    !host?.trim() ||
+                    payloadStatus !== "up" ||
+                    !saves ||
+                    saves.length === 0
+                  }
+                >
+                  {tr("saves_restore_usb_all", undefined, "Restore all from USB")}
+                </Button>
+              </>
+            )}
             <Button
               variant="secondary"
               size="sm"
@@ -868,62 +873,66 @@ export default function SavesScreen() {
                         {new Date(e.mtime * 1000).toLocaleDateString()}
                       </div>
                     </div>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      leftIcon={<Download size={11} />}
-                      onClick={() => handleDownload(e)}
-                      disabled={isBusy(e.path)}
-                    >
-                      {tr("saves_download", undefined, "Backup")}
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      leftIcon={<HardDrive size={11} />}
-                      onClick={() => handleBackupToUsb(e)}
-                      disabled={isBusy(e.path) || bulkBackupBusy}
-                      title={tr(
-                        "saves_backup_usb_tooltip",
-                        undefined,
-                        "Back this save up to the USB save path configured in Settings, without leaving the PS5.",
-                      )}
-                    >
-                      {tr("saves_backup_usb", undefined, "Save to USB")}
-                    </Button>
-                    {/* danger (red-bordered), NOT ghost like Backup: Restore
-                        overwrites — wipes — the live PS5 save. It sat visually
-                        identical to the harmless Backup button next to it,
-                        giving no at-a-glance signal which of the two is
-                        destructive. The confirm dialog still guards the click. */}
-                    <Button
-                      variant="danger"
-                      size="sm"
-                      leftIcon={<UploadIcon size={11} />}
-                      onClick={() => handleRestore(e)}
-                      disabled={isBusy(e.path)}
-                      title={tr(
-                        "saves_restore_tooltip",
-                        undefined,
-                        "Pick a .zip backup and upload its contents back to this save's PS5 path. Overwrites the live save.",
-                      )}
-                    >
-                      {tr("saves_restore", undefined, "Restore")}
-                    </Button>
-                    <Button
-                      variant="danger"
-                      size="sm"
-                      leftIcon={<HardDrive size={11} />}
-                      onClick={() => handleRestoreFromUsb(e)}
-                      disabled={isBusy(e.path) || bulkRestoreBusy}
-                      title={tr(
-                        "saves_restore_usb_tooltip",
-                        undefined,
-                        "Restore this save from its latest USB backup at the path configured in Settings, without leaving the PS5. Overwrites the live save.",
-                      )}
-                    >
-                      {tr("saves_restore_usb", undefined, "Restore from USB")}
-                    </Button>
+                    {isTauriEnv() && (
+                      <>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          leftIcon={<Download size={11} />}
+                          onClick={() => handleDownload(e)}
+                          disabled={isBusy(e.path)}
+                        >
+                          {tr("saves_download", undefined, "Backup")}
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          leftIcon={<HardDrive size={11} />}
+                          onClick={() => handleBackupToUsb(e)}
+                          disabled={isBusy(e.path) || bulkBackupBusy}
+                          title={tr(
+                            "saves_backup_usb_tooltip",
+                            undefined,
+                            "Back this save up to the USB save path configured in Settings, without leaving the PS5.",
+                          )}
+                        >
+                          {tr("saves_backup_usb", undefined, "Save to USB")}
+                        </Button>
+                        {/* danger (red-bordered), NOT ghost like Backup: Restore
+                            overwrites — wipes — the live PS5 save. It sat visually
+                            identical to the harmless Backup button next to it,
+                            giving no at-a-glance signal which of the two is
+                            destructive. The confirm dialog still guards the click. */}
+                        <Button
+                          variant="danger"
+                          size="sm"
+                          leftIcon={<UploadIcon size={11} />}
+                          onClick={() => handleRestore(e)}
+                          disabled={isBusy(e.path)}
+                          title={tr(
+                            "saves_restore_tooltip",
+                            undefined,
+                            "Pick a .zip backup and upload its contents back to this save's PS5 path. Overwrites the live save.",
+                          )}
+                        >
+                          {tr("saves_restore", undefined, "Restore")}
+                        </Button>
+                        <Button
+                          variant="danger"
+                          size="sm"
+                          leftIcon={<HardDrive size={11} />}
+                          onClick={() => handleRestoreFromUsb(e)}
+                          disabled={isBusy(e.path) || bulkRestoreBusy}
+                          title={tr(
+                            "saves_restore_usb_tooltip",
+                            undefined,
+                            "Restore this save from its latest USB backup at the path configured in Settings, without leaving the PS5. Overwrites the live save.",
+                          )}
+                        >
+                          {tr("saves_restore_usb", undefined, "Restore from USB")}
+                        </Button>
+                      </>
+                    )}
                   </li>
                 ))}
               </ul>

--- a/client/src/screens/Screenshots/index.tsx
+++ b/client/src/screens/Screenshots/index.tsx
@@ -35,6 +35,7 @@ import {
   isJxrScreenshot,
 } from "../../lib/screenshotConvert";
 import { isMobile } from "../../lib/platform";
+import { isTauriEnv } from "../../lib/tauriEnv";
 
 /** Map a full-res shot path to its (smaller) PS5 thumbnail path. The console
  *  stores `/user/av_contents/photo/.../X.jxr` and a thumbnail at
@@ -199,8 +200,10 @@ export default function ScreenshotsScreen() {
     new Set(),
   );
   // Convert (JPEG XR decode) is a desktop-only feature — the codec isn't
-  // bundled on mobile (Android/iOS) — so the button is hidden there.
-  const canConvert = !isMobile();
+  // bundled on mobile (Android/iOS) — so the button is hidden there. Also
+  // gated on isTauriEnv(): thumbnails/previews stage a local temp dir + use
+  // convertFileSrc, neither of which exists in a browser session.
+  const canConvert = !isMobile() && isTauriEnv();
 
   const allSelected = useMemo(() => {
     return !!items && items.length > 0 && selected.size === items.length;
@@ -518,7 +521,7 @@ export default function ScreenshotsScreen() {
         )}
         right={
           <div className="flex items-center gap-2">
-            {selected.size > 0 && (
+            {selected.size > 0 && isTauriEnv() && (
               <Button
                 variant="primary"
                 size="sm"
@@ -678,23 +681,25 @@ export default function ScreenshotsScreen() {
                     {tr("screenshots_convert", undefined, "Convert to PNG")}
                   </Button>
                 )}
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  leftIcon={
-                    busyPaths.has(item.path) ? (
-                      <Loader2 size={11} className="animate-spin" />
-                    ) : (
-                      <Download size={11} />
-                    )
-                  }
-                  onClick={() => downloadOne(item)}
-                  disabled={
-                    busyPaths.has(item.path) || convertingPaths.has(item.path)
-                  }
-                >
-                  {tr("screenshots_download", undefined, "Download")}
-                </Button>
+                {isTauriEnv() && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    leftIcon={
+                      busyPaths.has(item.path) ? (
+                        <Loader2 size={11} className="animate-spin" />
+                      ) : (
+                        <Download size={11} />
+                      )
+                    }
+                    onClick={() => downloadOne(item)}
+                    disabled={
+                      busyPaths.has(item.path) || convertingPaths.has(item.path)
+                    }
+                  >
+                    {tr("screenshots_download", undefined, "Download")}
+                  </Button>
+                )}
               </li>
             );
           })}
@@ -725,6 +730,7 @@ export default function ScreenshotsScreen() {
                 {preview.item.path.split("/").pop()}
               </span>
               <div className="flex shrink-0 items-center gap-2">
+                {isTauriEnv() && (
                 <Button
                   variant="secondary"
                   size="sm"
@@ -740,6 +746,7 @@ export default function ScreenshotsScreen() {
                 >
                   {tr("screenshots_download", undefined, "Download")}
                 </Button>
+                )}
                 <button
                   type="button"
                   onClick={closePreview}

--- a/client/src/screens/Search/index.tsx
+++ b/client/src/screens/Search/index.tsx
@@ -28,6 +28,7 @@ import { usePrompt } from "../../components/ConfirmDialog";
 import { pushNotification } from "../../state/notifications";
 import { useTr } from "../../state/lang";
 import { formatBytes } from "../../lib/format";
+import { isTauriEnv } from "../../lib/tauriEnv";
 
 /** Size filter options. `labelKey` resolves through `tr()` at render
  *  time; `labelFallback` is the English text used when the lang file
@@ -529,32 +530,43 @@ export default function SearchScreen() {
  *  RFC 4180 quoting (double-quote both wrappers and embedded quotes);
  *  JSON serializes the entire SearchHit shape. */
 async function exportSearchResults(hits: SearchHit[], format: "csv" | "json") {
-  const { save } = await import("@tauri-apps/plugin-dialog");
-  const { writeTextFileToPath } = await import("../../lib/saveTextFile");
   const fileName = `ps5upload-search-${Date.now()}.${format}`;
+  let text: string;
+  if (format === "json") {
+    text = JSON.stringify(hits, null, 2);
+  } else {
+    // CSV
+    const esc = (v: string | number) => {
+      const s = String(v);
+      if (/[",\n\r]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
+      return s;
+    };
+    const rows = ["path,name,size,kind"];
+    for (const h of hits) {
+      rows.push([h.path, h.name, h.size, h.kind].map(esc).join(","));
+    }
+    text = rows.join("\n");
+  }
   // Surface write failures (e.g. a read-only dest, disk full, Android SAF
   // error) instead of swallowing them — a failed export must not look like a
   // successful one.
   try {
-    const dest = await save({
-      defaultPath: fileName,
-      filters: [{ name: format.toUpperCase(), extensions: [format] }],
-    });
-    if (!dest || typeof dest !== "string") return;
-    if (format === "json") {
-      await writeTextFileToPath(dest, JSON.stringify(hits, null, 2), fileName);
+    if (!isTauriEnv()) {
+      const { browserDownloadText } = await import("../../lib/browserDownload");
+      browserDownloadText(
+        fileName,
+        text,
+        format === "json" ? "application/json" : "text/csv",
+      );
     } else {
-      // CSV
-      const esc = (v: string | number) => {
-        const s = String(v);
-        if (/[",\n\r]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
-        return s;
-      };
-      const rows = ["path,name,size,kind"];
-      for (const h of hits) {
-        rows.push([h.path, h.name, h.size, h.kind].map(esc).join(","));
-      }
-      await writeTextFileToPath(dest, rows.join("\n"), fileName);
+      const { save } = await import("@tauri-apps/plugin-dialog");
+      const { writeTextFileToPath } = await import("../../lib/saveTextFile");
+      const dest = await save({
+        defaultPath: fileName,
+        filters: [{ name: format.toUpperCase(), extensions: [format] }],
+      });
+      if (!dest || typeof dest !== "string") return;
+      await writeTextFileToPath(dest, text, fileName);
     }
     pushNotification("success", "Search results exported", {
       body: `Saved ${hits.length.toLocaleString()} ${format.toUpperCase()} rows.`,

--- a/client/src/screens/Settings/index.tsx
+++ b/client/src/screens/Settings/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   Settings as SettingsIcon,
   Moon as SleepIcon,
@@ -31,6 +31,7 @@ import {
 } from "../../state/uiScale";
 
 import { PageHeader } from "../../components";
+import { isTauriEnv } from "../../lib/tauriEnv";
 import { useConfirm } from "../../components/ConfirmDialog";
 
 import { useKeepAwakeStore } from "../../state/keepAwake";
@@ -911,6 +912,7 @@ function BackupRestorePanel() {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [info, setInfo] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   // Backup captures EVERY persisted key in the app's `ps5upload.` namespace via
   // a prefix scan, rather than a hand-maintained allowlist. The old allowlist
@@ -927,8 +929,6 @@ function BackupRestorePanel() {
     setError(null);
     setInfo(null);
     try {
-      const { save } = await import("@tauri-apps/plugin-dialog");
-      const { writeTextFileToPath } = await import("../../lib/saveTextFile");
       const bundle: Record<string, unknown> = {
         meta: {
           generated_at_ms: Date.now(),
@@ -944,16 +944,21 @@ function BackupRestorePanel() {
         }
       }
       const fileName = `ps5upload-settings-${Date.now()}.json`;
+      const json = JSON.stringify(bundle, null, 2);
+      if (!isTauriEnv()) {
+        const { browserDownloadText } = await import("../../lib/browserDownload");
+        browserDownloadText(fileName, json, "application/json");
+        setInfo(`Downloaded ${fileName}`);
+        return;
+      }
+      const { save } = await import("@tauri-apps/plugin-dialog");
+      const { writeTextFileToPath } = await import("../../lib/saveTextFile");
       const dest = await save({
         defaultPath: fileName,
         filters: [{ name: "JSON", extensions: ["json"] }],
       });
       if (!dest || typeof dest !== "string") return;
-      await writeTextFileToPath(
-        dest,
-        JSON.stringify(bundle, null, 2),
-        fileName,
-      );
+      await writeTextFileToPath(dest, json, fileName);
       setInfo(`Saved to ${dest}`);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
@@ -962,7 +967,45 @@ function BackupRestorePanel() {
     }
   }
 
+  /** Shared validate-and-apply step for an import bundle's raw JSON text —
+   *  used by both the native (file-path) and browser (`<input type=file>`)
+   *  read paths below. */
+  function applyBundleText(text: string): number {
+    const parsed = JSON.parse(text);
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      typeof parsed.local_storage !== "object"
+    ) {
+      throw new Error("file is not a ps5upload settings bundle");
+    }
+    const ls = parsed.local_storage as Record<string, unknown>;
+    const actions: Array<{ key: string; value: string | null }> = [];
+    for (const k of Object.keys(ls)) {
+      // Safety: only ever touch our own namespace, so a hand-edited or
+      // malicious bundle can't write arbitrary localStorage keys.
+      if (!k.startsWith(NS_PREFIX)) continue;
+      const v = ls[k];
+      if (typeof v === "string") {
+        actions.push({ key: k, value: v });
+      } else if (v === null) {
+        actions.push({ key: k, value: null });
+      } else if (v !== undefined) {
+        throw new Error(`invalid value for ${k}`);
+      }
+    }
+    for (const { key, value } of actions) {
+      if (value === null) window.localStorage.removeItem(key);
+      else window.localStorage.setItem(key, value);
+    }
+    return actions.length;
+  }
+
   async function importBundle() {
+    if (!isTauriEnv()) {
+      fileInputRef.current?.click();
+      return;
+    }
     setBusy(true);
     setError(null);
     setInfo(null);
@@ -975,39 +1018,34 @@ function BackupRestorePanel() {
       });
       if (!src || typeof src !== "string") return;
       const text = await readTextFileFromPath(src);
-      const parsed = JSON.parse(text);
-      if (
-        !parsed ||
-        typeof parsed !== "object" ||
-        typeof parsed.local_storage !== "object"
-      ) {
-        throw new Error("file is not a ps5upload settings bundle");
-      }
-      const ls = parsed.local_storage as Record<string, unknown>;
-      const actions: Array<{ key: string; value: string | null }> = [];
-      for (const k of Object.keys(ls)) {
-        // Safety: only ever touch our own namespace, so a hand-edited or
-        // malicious bundle can't write arbitrary localStorage keys.
-        if (!k.startsWith(NS_PREFIX)) continue;
-        const v = ls[k];
-        if (typeof v === "string") {
-          actions.push({ key: k, value: v });
-        } else if (v === null) {
-          actions.push({ key: k, value: null });
-        } else if (v !== undefined) {
-          throw new Error(`invalid value for ${k}`);
-        }
-      }
-      for (const { key, value } of actions) {
-        if (value === null) window.localStorage.removeItem(key);
-        else window.localStorage.setItem(key, value);
-      }
-      const restored = actions.length;
+      const restored = applyBundleText(text);
       setInfo(
         `Restored ${restored} key${restored === 1 ? "" : "s"}. Restart the app for all changes to take effect.`,
       );
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleBrowserFileInput(
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) {
+    const file = e.target.files?.[0];
+    e.target.value = ""; // allow re-picking the same file name later
+    if (!file) return;
+    setBusy(true);
+    setError(null);
+    setInfo(null);
+    try {
+      const text = await file.text();
+      const restored = applyBundleText(text);
+      setInfo(
+        `Restored ${restored} key${restored === 1 ? "" : "s"}. Restart the app for all changes to take effect.`,
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
     } finally {
       setBusy(false);
     }
@@ -1044,6 +1082,16 @@ function BackupRestorePanel() {
         >
           {tr("settings_backup_import", undefined, "Import bundle…")}
         </button>
+        {/* Hidden — the browser's own file picker, triggered programmatically
+            by importBundle() when !isTauriEnv(). Desktop uses the native
+            dialog instead (see importBundle). */}
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".json,application/json"
+          className="hidden"
+          onChange={(e) => void handleBrowserFileInput(e)}
+        />
       </div>
       {info && (
         <div className="flex items-center gap-1 text-xs text-[var(--color-good)]">

--- a/client/src/screens/Stats/index.tsx
+++ b/client/src/screens/Stats/index.tsx
@@ -13,6 +13,7 @@ import { PageHeader, Button } from "../../components";
 import { useTr } from "../../state/lang";
 import { formatBytes } from "../../lib/format";
 import { pushNotification } from "../../state/notifications";
+import { isTauriEnv } from "../../lib/tauriEnv";
 
 /**
  * Activity stats dashboard.
@@ -39,18 +40,23 @@ export default function StatsScreen() {
   async function exportCsv() {
     if (entries.length === 0) return;
     const fileName = `ps5upload-activity-${Date.now()}.csv`;
+    const csv = activityToCsv(entries);
     // Surface write failures instead of swallowing them — a failed export must
     // not silently look like it succeeded.
     try {
-      const { save } = await import("@tauri-apps/plugin-dialog");
-      const { writeTextFileToPath } = await import("../../lib/saveTextFile");
-      const dest = await save({
-        defaultPath: fileName,
-        filters: [{ name: "CSV", extensions: ["csv"] }],
-      });
-      if (!dest || typeof dest !== "string") return;
-      const csv = activityToCsv(entries);
-      await writeTextFileToPath(dest, csv, fileName);
+      if (!isTauriEnv()) {
+        const { browserDownloadText } = await import("../../lib/browserDownload");
+        browserDownloadText(fileName, csv, "text/csv");
+      } else {
+        const { save } = await import("@tauri-apps/plugin-dialog");
+        const { writeTextFileToPath } = await import("../../lib/saveTextFile");
+        const dest = await save({
+          defaultPath: fileName,
+          filters: [{ name: "CSV", extensions: ["csv"] }],
+        });
+        if (!dest || typeof dest !== "string") return;
+        await writeTextFileToPath(dest, csv, fileName);
+      }
       pushNotification("success", "Activity exported", {
         body: `Saved ${entries.length.toLocaleString()} rows.`,
       });

--- a/client/src/screens/Videos/index.tsx
+++ b/client/src/screens/Videos/index.tsx
@@ -28,6 +28,7 @@ import { pickPath } from "../../lib/pickPath";
 import { formatBytes } from "../../lib/format";
 import { basename } from "../../lib/uploadDest";
 import { isMobile } from "../../lib/platform";
+import { isTauriEnv } from "../../lib/tauriEnv";
 
 /** Join a dir + name the same way the screenshot flow does (mirrors
  *  lib/screenshotConvert.joinDir, kept local so Videos has no dependency on
@@ -62,8 +63,9 @@ export default function VideosScreen() {
   const [bulkBusy, setBulkBusy] = useState(false);
   const [busyPaths, setBusyPaths] = useState<Set<string>>(new Set());
   // Inline <video> preview is desktop-only (streams a downloaded copy from a
-  // scratch dir via convertFileSrc — no mobile file-serving equivalent).
-  const canPreview = !isMobile();
+  // scratch dir via convertFileSrc — no mobile file-serving equivalent, and
+  // no browser equivalent either since there's no host temp dir there).
+  const canPreview = !isMobile() && isTauriEnv();
 
   const allSelected = useMemo(
     () => !!items && items.length > 0 && selected.size === items.length,
@@ -281,7 +283,7 @@ export default function VideosScreen() {
         )}
         right={
           <div className="flex items-center gap-2">
-            {selected.size > 0 && (
+            {selected.size > 0 && isTauriEnv() && (
               <Button
                 variant="primary"
                 size="sm"
@@ -395,19 +397,21 @@ export default function VideosScreen() {
                     <Eye size={13} />
                   </button>
                 )}
-                <button
-                  type="button"
-                  onClick={() => void downloadOne(item)}
-                  disabled={rowBusy}
-                  className="inline-flex items-center gap-1 rounded px-1.5 py-1 text-[var(--color-muted)] hover:text-[var(--color-text)] disabled:opacity-50"
-                  aria-label={tr("videos_download", undefined, "Download")}
-                >
-                  {rowBusy ? (
-                    <Loader2 size={13} className="animate-spin" />
-                  ) : (
-                    <Download size={13} />
-                  )}
-                </button>
+                {isTauriEnv() && (
+                  <button
+                    type="button"
+                    onClick={() => void downloadOne(item)}
+                    disabled={rowBusy}
+                    className="inline-flex items-center gap-1 rounded px-1.5 py-1 text-[var(--color-muted)] hover:text-[var(--color-text)] disabled:opacity-50"
+                    aria-label={tr("videos_download", undefined, "Download")}
+                  >
+                    {rowBusy ? (
+                      <Loader2 size={13} className="animate-spin" />
+                    ) : (
+                      <Download size={13} />
+                    )}
+                  </button>
+                )}
               </li>
             );
           })}


### PR DESCRIPTION
## Description

Capability gating for the browser web UI (follow-up to #171/#186): hides
or disables affordances that need a host OS file picker, local
filesystem access, or another Tauri-only API with no browser
equivalent, instead of letting a browser user click a button that
throws `BrowserUnsupportedError` or silently does nothing.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Changes Made

**Hidden entirely** (nav entry + route redirect via a new `NativeOnlyRoute` guard in `App.tsx`, and `hideInBrowser` on the `Sidebar.tsx` nav item) — no browser-functional path exists at all:
- Upload — every affordance is a host file/folder picker; no browser upload path exists anywhere in the screen.
- Payloads (Catalog + Send tabs) — both download/cache the payload to a local host directory before pushing it to the PS5's loader port.

**Gated per-button**, screen stays usable:
- Connection — Step 2 "Send helper" and the outdated-payload "Replace helper" button (the bundled ELF push reads a local file); shows an explanatory message in the browser instead of a dead button.
- InstallPackage — local `.pkg` picker buttons hidden; the USB-on-PS5 install path (`ExternalPackages`, scans `/mnt/usb*` on the console itself) stays fully functional — it doesn't touch the host filesystem.
- Profile — avatar file picker.
- Saves — all 4 backup/restore actions gated, including the "USB" variants: tracing through `backupOneToUsb`/`restoreOneFromUsb` showed they *also* round-trip through a host-side scratch dir (`saveArchiveMakeTemp`/`saveArchiveZip`) even though the source/destination is the PS5's own USB drive. Only the save *list* stays browser-safe.
- FileSystem — download / download-as-zip buttons.
- Screenshots/Videos — thumbnail + lightbox/inline preview and per-item/bulk download (all stage a local temp dir and use `convertFileSrc`); extended the screens' existing `canConvert`/`canPreview` capability flags to also require `isTauriEnv()`.
- BugReport — attach file, create report (zip needs a save dialog), open-logs-folder.
- Logs — open-logs-folder.
- ErrorBoundary — "Report this crash" previously silently no-op'd in a browser (the whole zip-and-save flow throws and is swallowed by design); now falls back to just opening the Discord channel.

**Given an actual browser implementation instead of just hiding**, since the underlying data is already browser-portable:
- Search / Stats / Logs exports — Blob + anchor download (new `lib/browserDownload.ts`). Safe in a real browser even though the same Blob/anchor approach is explicitly avoided on desktop (a comment in `AppLogsPanel.tsx` explains the Tauri webview intercepts anchor downloads and routes them through an ACL-blocked command — that interception is Tauri-webview-only and doesn't apply outside it).
- Settings backup/restore — Blob download for export, a hidden `<input type=file>` for import. The settings themselves already live in `localStorage`, so only the disk I/O needed a browser-side path; shared the parse/validate logic (`applyBundleText`) between both read paths.
- `getVersion()` everywhere (Sidebar, AppShell, About, Connection, BugReport) — new `lib/appVersion.ts` hits the engine's own `GET /api/version` in a browser (unwrapping its `{version}` envelope) instead of the Tauri `app` plugin, which doesn't exist there.

Deliberately left unchanged (already degrade correctly by design, confirmed by reading each): `ensurePayloadCurrent.ts` (doc-commented "never throws," already returns `"no-push"` on any native call failure) and `crashReporter.ts` (doc-commented "must never surface its own failure... e.g. non-Tauri context").

## Documentation Updates

**Did you update the documentation?** [ ] Yes [x] No

If no documentation updates: same reasoning as #171/#186 — the self-hosted README section is planned once the full browser experience (this gating pass) is complete, so it can document the whole thing in one place.

## Testing

- [x] `npm run validate` equivalent: `typecheck`, `lint`, full Vitest suite (72 files / 782 tests) — all green.
- [ ] `npm run coverage`
- [ ] Built PS5 payload successfully
- [ ] Cross-platform CI target checks passed
- [ ] Tested on real PS5 hardware
- [ ] Tested desktop app
- [x] Verified all example commands in docs work — started a live Vite dev server and curl'd every touched file's module path through it (all 200s, confirming clean transforms with no syntax/JSX errors) in addition to the type checker.
- [x] Tested edge cases and error handling — traced through each native-only flow to confirm it (a) genuinely has no browser path before hiding it (e.g. discovered the Saves "USB" backup/restore buttons need a host scratch dir too, which wasn't obvious from the button labels), and (b) that gating a trigger point makes any downstream native call (e.g. Profile's `confirm()` dialog, Screenshots' preview lightbox) unreachable rather than leaving a dangling half-gated path.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation to reflect my changes
- [x] My changes generate no new warnings
- [ ] I have tested my changes on PS5 hardware (or simulated environment)
- [ ] All example code in documentation has been tested and works

## Additional Notes

No Rust code changed in this PR — it's frontend-only, so the earlier Rust-toolchain verification notes from #171/#186 don't apply here.

This was scoped by first surveying every native-only call site across the app (file pickers, `localFs`, save-archive host temp/zip, payload send, `convertFileSrc`, window state, `diag_log_open_dir`, `getVersion`) before deciding hide-whole-screen vs. gate-per-button vs. build-a-real-browser-fallback for each — several turned out to have partially or fully browser-safe paths that weren't obvious from the original plan (InstallPackage's USB-on-PS5 install, Settings' localStorage-backed backup/restore), so this isn't a mechanical "wrap everything in `isTauriEnv()`" pass.

Remaining before the browser web UI is fully documented: the README self-hosted section covering the `ps5upload-engine-webui` Docker image and `PS5UPLOAD_ALLOW_IP`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)