### PR TITLE
docs: document the self-hosted browser web UI

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -632,14 +632,27 @@ all-in-one mode.
 **Q: Can I use ps5upload from a web browser (no desktop app)? (3.3.25)**
 Yes. A `webui` build of the engine serves the **full app over HTTP**, so you
 can manage your PS5 from any browser on your LAN — useful on a NAS or headless
-box where you don't want to install the desktop app. Build the browser image
-with `docker build -f engine/Dockerfile.webui -t ps5upload-engine-webui .`,
-run it, and open `http://<host>:19113`. Same security rules as the self-hosted
-engine above: it's **unauthenticated**, so only reach it from IPs you add to
+box where you don't want to install the desktop app. An official multi-arch
+image is published at `ghcr.io/phantomptr/ps5upload-engine-webui` (`:latest`
+or `:<version>`); or build it yourself with
+`docker build -f engine/Dockerfile.webui -t ps5upload-engine-webui .` (run
+that from the **repo root**, not `engine/` — the build needs `client/` to
+compile the frontend first). Run it the same way as the plain engine image
+and open `http://<host>:19113`. Same security rules as the self-hosted engine
+above: it's **unauthenticated**, so only reach it from IPs you add to
 `PS5UPLOAD_ALLOW_IP`, and only on a trusted LAN — never expose port 19113 to
-the internet. (Host-side actions that need your PC's own filesystem — picking a
-local file to upload — are desktop-only; everything that operates on the PS5
-works in the browser.)
+the internet.
+
+Actions that need your PC's own filesystem are desktop-only and hidden in the
+browser UI: Upload and Payloads (both require picking a local file) are
+hidden from the sidebar entirely; on other screens, only the specific
+affordance that needs a local file is hidden — installing a `.pkg` you pick
+from your PC, saving a save-data backup to your computer (even the
+"back up to USB" flow round-trips through a local scratch file), downloading
+a file/screenshot/video clip, and attaching a file to a bug report. Everything
+that operates on the PS5 itself — browse, transfer, install from a
+PS5-connected USB drive, hardware monitor, saves list, profile — works the
+same as the desktop app.
 
 **Q: What is "Stream (beta)" on the Install Package screen? (3.3.25)**
 It installs a `.pkg` **straight from your PC over HTTP** — the PS5 pulls the

--- a/README.md
+++ b/README.md
@@ -467,6 +467,26 @@ below 4.x is obscure and above 12.70 is future work.
   unauthenticated (it can read/write/delete PS5 files), so only do this on a
   trusted LAN — never expose the engine to the internet.
 
+**Q: Can I run ps5upload from a browser, with no desktop app at all (self-hosted web UI)?**
+* Yes (3.3.25+). A separate `webui` build of the engine serves the **full
+  React app over HTTP**, so you can manage your PS5 from any browser on the
+  LAN — handy for a NAS or headless box you don't want to install the desktop
+  client on. An official multi-arch image is published at
+  `ghcr.io/phantomptr/ps5upload-engine-webui` (`:latest` or `:<version>`); or
+  build it yourself with
+  `docker build -f engine/Dockerfile.webui -t ps5upload-engine-webui .`
+  (build context is the **repo root**, not `engine/` — it needs `client/` to
+  build the frontend first). Run it the same way as the plain engine image
+  (`PS5_ADDR`, `PS5UPLOAD_ALLOW_IP`) and open `http://<host>:19113` in a
+  browser on an allowlisted IP. Same security model as the remote engine
+  above: **unauthenticated**, LAN-only, never expose it to the internet.
+  Actions that need your PC's own filesystem — picking a local file to
+  upload or install, sending a payload from disk, saving a save-data backup
+  to your computer — are desktop-only and hidden in the browser UI;
+  everything that operates on the PS5 itself (browse, transfer, install from
+  a PS5-connected USB drive, hardware monitor, saves list, …) works the same
+  as the desktop app.
+
 ## Contributing
 
 - Report bugs:


### PR DESCRIPTION
## Description

Documents the browser web UI (#171, #186, #187, #188) in both README.md
and FAQ.md, and brings FAQ.md's existing webui entry up to date with
the CI publish pipeline that shipped after it was originally written.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Changes Made

- `README.md`: added a new self-hosted FAQ entry, "Can I run ps5upload from a browser, with no desktop app at all (self-hosted web UI)?", right after the existing remote-engine entry. The "Web browser access" feature bullet earlier in the README already said "See the self-hosted-engine FAQ below" but no such entry existed yet — this closes that gap.
- `FAQ.md`: FAQ.md already had a "Can I use ps5upload from a web browser" entry from an earlier merge, but it only covered building `Dockerfile.webui` by hand (`docker build -f engine/Dockerfile.webui ...`). It predates #187, which added the CI pipeline that now publishes an official multi-arch image at `ghcr.io/phantomptr/ps5upload-engine-webui` — updated to lead with that, keeping the manual build as the alternative.
- Both entries' "what's desktop-only" caveat is expanded to match what #188's capability-gating pass actually shipped: Upload and Payloads are hidden from the sidebar entirely (no browser-functional path at all), while other screens gate only the specific native affordance (local `.pkg` picker, save backup/restore-to-file — including the "back up to USB" flow, which turned out to round-trip through a local scratch file too — file/screenshot/video download, bug-report attachments). The previous FAQ.md wording ("picking a local file to upload") undersold how much was actually gated.

## Documentation Updates

**Did you update the documentation?** [x] Yes [ ] No

Files: `README.md`, `FAQ.md` (this PR is exclusively documentation).

## Testing

- [ ] `npm run validate`
- [ ] `npm run coverage`
- [ ] Built PS5 payload successfully
- [ ] Cross-platform CI target checks passed
- [ ] Tested on real PS5 hardware
- [ ] Tested desktop app
- [x] Verified all example commands in docs work — checked `scripts/validate-repo.mjs` for any markdown/docs validation step (none exists, so nothing else in the quality gate touches these files); the `docker build` command referenced was already verified working end-to-end when #171 was built and run via Docker, and the `ghcr.io/phantomptr/ps5upload-engine-webui` image name matches exactly what #187's CI workflow derives and publishes.
- [x] Tested edge cases and error handling — cross-checked the "what's desktop-only" list in both files against the actual gating that landed in #188 (Sidebar.tsx's `hideInBrowser`, and each per-screen `isTauriEnv()` gate) rather than restating the pre-#188 assumption.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation to reflect my changes
- [x] My changes generate no new warnings
- [ ] I have tested my changes on PS5 hardware (or simulated environment)
- [ ] All example code in documentation has been tested and works

## Additional Notes

This is the last item from the original browser-web-UI plan (Phase 1 → Phase 2 → capability gating → docs). No code changes in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)