### PR TITLE
feat(webui): restore Upload in the browser via the engine's own filesystem

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -643,8 +643,21 @@ above: it's **unauthenticated**, so only reach it from IPs you add to
 `PS5UPLOAD_ALLOW_IP`, and only on a trusted LAN — never expose port 19113 to
 the internet.
 
-Actions that need your PC's own filesystem are desktop-only and hidden in the
-browser UI: Upload and Payloads (both require picking a local file) are
+**Upload works in the browser** — but it picks files from the **engine's
+own filesystem**, not the browser machine's. There's no way for a browser
+tab to read files off a *different* computer's disk (the one running the
+engine), so the in-app file/folder picker instead browses whatever the
+engine process can see — e.g. mount a folder into the Docker container
+with `-v /host/games:/data/games` and browse to `/data/games`. Plain files
+and folders upload the same as desktop; **archive uploads (`.zip`/`.7z`/
+`.rar`) are still desktop-only** for now (the archive-inspect step streams
+progress in a way the browser shim doesn't support yet — picking one shows
+a clear "not available in the browser yet" message instead of failing
+silently). The upload **queue also doesn't persist across a full page
+reload** in browser mode (queue persistence is desktop-only).
+
+Other actions that need your PC's own filesystem are still desktop-only and
+hidden in the browser UI: **Payloads** (sending a `.elf`/etc. from disk) is
 hidden from the sidebar entirely; on other screens, only the specific
 affordance that needs a local file is hidden — installing a `.pkg` you pick
 from your PC, saving a save-data backup to your computer (even the

--- a/README.md
+++ b/README.md
@@ -480,12 +480,20 @@ below 4.x is obscure and above 12.70 is future work.
   (`PS5_ADDR`, `PS5UPLOAD_ALLOW_IP`) and open `http://<host>:19113` in a
   browser on an allowlisted IP. Same security model as the remote engine
   above: **unauthenticated**, LAN-only, never expose it to the internet.
-  Actions that need your PC's own filesystem — picking a local file to
-  upload or install, sending a payload from disk, saving a save-data backup
-  to your computer — are desktop-only and hidden in the browser UI;
-  everything that operates on the PS5 itself (browse, transfer, install from
-  a PS5-connected USB drive, hardware monitor, saves list, …) works the same
-  as the desktop app.
+  **Upload works in the browser** too, operating on files already
+  present on the **engine's own machine** — e.g. mount a folder into the
+  container with `-v /host/games:/data/games`, then browse to `/data/games`
+  in the in-app file picker. That picker browses the *engine's* filesystem,
+  not the browser's own machine — a browser tab has no way to reach a
+  remote engine's disk except through what the engine itself can already
+  read. A few things are still desktop-only and hidden in the browser UI:
+  archive uploads (`.zip`/`.7z`/`.rar`), Payloads (sending a `.elf`/etc. from
+  disk), installing a `.pkg` you pick from your PC, and saving a save-data
+  backup to your computer — everything else that operates on the PS5 itself
+  (browse, transfer, install from a PS5-connected USB drive, hardware
+  monitor, saves list, …) works the same as the desktop app. The upload
+  queue also doesn't persist across a full page reload in browser mode
+  (queue persistence is desktop-only).
 
 ## Contributing
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -103,11 +103,9 @@ export default function App() {
         <Route
           path="/upload"
           element={
-            <NativeOnlyRoute>
-              <Suspense fallback={<ScreenLoader />}>
-                <UploadScreen />
-              </Suspense>
-            </NativeOnlyRoute>
+            <Suspense fallback={<ScreenLoader />}>
+              <UploadScreen />
+            </Suspense>
           }
         />
         <Route

--- a/client/src/api/localFs.ts
+++ b/client/src/api/localFs.ts
@@ -3,8 +3,12 @@
 // dialog returns content:// URIs the engine can't read, so we browse the
 // real filesystem here instead. Commands live in
 // client/src-tauri/src/commands/local_fs.rs.
+//
+// In a browser session (no Tauri) this instead browses the ENGINE's own
+// filesystem via `invokeLogged` → `browserInvoke` → the engine's
+// /api/local/* routes (see engine/crates/ps5upload-engine/src/local_fs.rs).
 
-import { invoke } from "@tauri-apps/api/core";
+import { invoke } from "../lib/invokeLogged";
 
 export interface LocalEntry {
   name: string;

--- a/client/src/layout/Sidebar.tsx
+++ b/client/src/layout/Sidebar.tsx
@@ -127,7 +127,6 @@ const items: NavItem[] = [
     fallback: "Upload",
     icon: Upload,
     section: { key: "nav_section_files", fallback: "Files" },
-    hideInBrowser: true,
   },
   {
     to: "/install-package",

--- a/client/src/lib/browserInvoke.ts
+++ b/client/src/lib/browserInvoke.ts
@@ -545,6 +545,47 @@ export async function browserInvoke<T>(cmd: string, args: AnyArgs = {}): Promise
     case "smp_status":
       return getJson<T>(addrUrl("/api/ps5/smp/status", args["addr"]));
 
+    // ── Local (engine host) filesystem browse ───────────────────────────────
+    // Browser-mode counterpart to the Tauri file/folder dialog: browses the
+    // ENGINE's own filesystem (e.g. a Docker container's mounted volumes),
+    // backing the same in-app picker (LocalPathPicker) Android already uses.
+
+    case "local_list_dir":
+      return getJson<T>(`/api/local/list-dir?path=${uenc(args["path"] as string)}`);
+
+    case "local_storage_roots":
+      return getJson<T>("/api/local/storage-roots");
+
+    case "storage_access_granted":
+      // No scoped-storage concept in a browser — always granted, matching
+      // the Tauri command's own non-Android ("desktop") behavior.
+      return true as unknown as T;
+
+    case "request_storage_access":
+      // No permission to request in a browser — no-op, matching the Tauri
+      // command's own non-Android behavior.
+      return undefined as unknown as T;
+
+    // ── Transfer jobs (Upload screen) ───────────────────────────────────────
+    // These take a plain local path the ENGINE reads via std::fs — same
+    // contract whether that's the Tauri desktop's bundled engine or a
+    // Dockerized one. The TS wrapper's `req` already carries the exact
+    // snake_case body the engine handler deserializes, so it's forwarded
+    // verbatim (no field remapping, unlike some older hand-written cases).
+
+    case "transfer_file":
+      return postJson<T>("/api/transfer/file", args["req"], /*long=*/ true);
+
+    case "transfer_dir":
+      return postJson<T>("/api/transfer/dir", args["req"], /*long=*/ true);
+
+    case "transfer_dir_reconcile":
+      return postJson<T>(
+        "/api/transfer/dir-reconcile",
+        args["req"],
+        /*long=*/ true,
+      );
+
     // ── Native-only / unsupported ────────────────────────────────────────────
 
     default:

--- a/client/src/screens/Upload/index.tsx
+++ b/client/src/screens/Upload/index.tsx
@@ -250,8 +250,12 @@ export default function UploadScreen() {
   const handleChooseFile = async () => {
     try {
       // Android: the native dialog returns content:// URIs the engine
-      // can't read, so browse the real filesystem in-app instead.
-      const selected = isAndroid()
+      // can't read, so browse the real filesystem in-app instead. Browser
+      // (no Tauri): there's no native dialog at all, and it would browse
+      // the wrong machine anyway (the browser's, not the engine's) — same
+      // in-app browser, pointed at the engine's filesystem instead (see
+      // api/localFs.ts).
+      const selected = isAndroid() || !isTauriEnv()
         ? await pickLocalPath({ mode: "file" })
         : await openDialog({ directory: false, multiple: false });
       if (typeof selected !== "string") return;
@@ -271,8 +275,10 @@ export default function UploadScreen() {
   const handleChooseFolder = async () => {
     try {
       // Android: directory:true is a no-op in plugin-dialog; use the
-      // in-app real-path browser so folder upload works.
-      const selected = isAndroid()
+      // in-app real-path browser so folder upload works. Browser (no
+      // Tauri): same in-app browser, pointed at the engine's own
+      // filesystem instead — see handleChooseFile above.
+      const selected = isAndroid() || !isTauriEnv()
         ? await pickLocalPath({ mode: "folder" })
         : await openDialog({ directory: true, multiple: false });
       if (typeof selected === "string") await pickFolder(selected);

--- a/client/src/state/upload.ts
+++ b/client/src/state/upload.ts
@@ -11,6 +11,7 @@ import {
 } from "../api/ps5";
 import { useConnectionStore } from "./connection";
 import { hostOf } from "../lib/addr";
+import { isTauriEnv } from "../lib/tauriEnv";
 
 /**
  * Detected source kind. Drives which options the Upload screen shows.
@@ -318,6 +319,19 @@ export const useUploadStore = create<UploadState>((set, get) => ({
           }`,
         });
       }
+      return;
+    }
+    // Archive (.zip/.7z/.rar) upload isn't wired into the browser shim yet —
+    // the inspect step below streams progress over a Tauri Channel with no
+    // browser equivalent (see browserInvoke.ts). Refuse cleanly here rather
+    // than let it hit BrowserUnsupportedError mid-inspect.
+    if (isArchivePath(path) && !isTauriEnv()) {
+      set({
+        source: { kind: "archive", path, meta: null, wrappedHint: null, zipInfo: null },
+        detecting: false,
+        detectError:
+          "Archive upload (.zip/.7z/.rar) isn't available in the browser yet — pick a plain file or folder, or use the desktop app.",
+      });
       return;
     }
     // A .zip is an archive source: optimistically mark it, then inspect the

--- a/engine/crates/ps5upload-engine/src/lib.rs
+++ b/engine/crates/ps5upload-engine/src/lib.rs
@@ -34,6 +34,7 @@
 //!   GET  /api/ps5/list-dir?path=...   → list immediate children of a directory on PS5
 
 mod engine_log;
+mod local_fs;
 mod pkg_install;
 #[cfg(feature = "webui")]
 mod webui;
@@ -1207,6 +1208,39 @@ async fn ps5_list_dir(
         Ok(v) => (StatusCode::OK, Json(v)).into_response(),
         Err(e) => json_err(StatusCode::BAD_GATEWAY, format!("{e:#}")).into_response(),
     }
+}
+
+// ─── Local (engine host) filesystem browse ─────────────────────────────────
+//
+// Browser-mode counterpart to the Tauri desktop app's native file dialog —
+// browses the ENGINE's own filesystem (e.g. a Docker container's mounted
+// volumes), not the PS5's (see `ps5_list_dir` above) and not the browser's
+// own machine (impossible for a remote client). See `local_fs` module doc
+// for why this doesn't expand what the engine can already be asked to read
+// (the transfer routes already accept any caller-supplied local path).
+
+#[derive(Deserialize)]
+struct LocalListDirQuery {
+    path: String,
+}
+
+/// GET /api/local/list-dir?path=/data/games
+async fn local_list_dir_handler(Query(q): Query<LocalListDirQuery>) -> impl IntoResponse {
+    let path = q.path;
+    let result: Result<Vec<local_fs::LocalEntry>, anyhow::Error> =
+        tokio::task::spawn_blocking(move || local_fs::list_dir(&path))
+            .await
+            .map_err(anyhow::Error::from)
+            .and_then(|inner| inner);
+    match result {
+        Ok(v) => (StatusCode::OK, Json(v)).into_response(),
+        Err(e) => json_err(StatusCode::BAD_GATEWAY, format!("{e:#}")).into_response(),
+    }
+}
+
+/// GET /api/local/storage-roots
+async fn local_storage_roots_handler() -> impl IntoResponse {
+    (StatusCode::OK, Json(local_fs::storage_roots())).into_response()
 }
 
 // ─── Destructive FS ops ─────────────────────────────────────────────────────
@@ -6378,6 +6412,8 @@ async fn run(cfg: EngineConfig) -> anyhow::Result<()> {
         .route("/api/ps5/pkg/scan-external", get(ps5_pkg_scan_external))
         .route("/api/ps5/pkg/metadata", get(ps5_pkg_metadata))
         .route("/api/ps5/list-dir", get(ps5_list_dir))
+        .route("/api/local/list-dir", get(local_list_dir_handler))
+        .route("/api/local/storage-roots", get(local_storage_roots_handler))
         .route("/api/ps5/fs/delete", post(ps5_fs_delete))
         .route("/api/ps5/fs/move", post(ps5_fs_move))
         .route("/api/ps5/fs/copy", post(ps5_fs_copy))

--- a/engine/crates/ps5upload-engine/src/local_fs.rs
+++ b/engine/crates/ps5upload-engine/src/local_fs.rs
@@ -1,0 +1,110 @@
+//! Browse the engine's OWN local filesystem — the browser-mode counterpart
+//! to the Tauri desktop app's native file/folder dialog.
+//!
+//! The Tauri app picks files with a native OS dialog, which returns a real
+//! filesystem path on the SAME machine the app (and its bundled engine)
+//! runs on. A browser client has no such dialog — there is no way for an
+//! HTML `<input type="file">` to browse anything other than the browser's
+//! own machine, which usually isn't where the engine runs (e.g. the engine
+//! is in a Docker container, the browser is on another device entirely).
+//!
+//! So in browser mode the picker instead browses the *engine's* filesystem
+//! directly — the same real-path browser built for Android's scoped-storage
+//! problem (`client/src-tauri/src/commands/local_fs.rs`, `LocalPathPicker`
+//! in the frontend), just pointed at these HTTP routes instead of Tauri
+//! commands. A user who mounts files into the container (e.g. `docker run
+//! -v /host/games:/data/games ...`) can browse to `/data/games` here and
+//! transfer from there — `POST /api/transfer/file`/`/dir` already read an
+//! arbitrary caller-supplied local path, so this listing route doesn't
+//! expand what the engine can already be asked to read; it only makes that
+//! existing capability browsable instead of requiring the exact path to be
+//! known in advance.
+//!
+//! Ported from the non-Android branch of the Tauri command file above,
+//! which has zero Tauri-specific APIs to begin with.
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct LocalEntry {
+    pub name: String,
+    pub path: String,
+    pub is_dir: bool,
+    pub size: u64,
+}
+
+/// List a real local directory: directories first, then files, each
+/// alphabetical (case-insensitive). Unreadable entries are skipped rather
+/// than failing the whole listing.
+pub fn list_dir(path: &str) -> Result<Vec<LocalEntry>> {
+    let rd = std::fs::read_dir(path).with_context(|| format!("read_dir {path}"))?;
+    let mut out: Vec<LocalEntry> = Vec::new();
+    for ent in rd.flatten() {
+        let md = match ent.metadata() {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        out.push(LocalEntry {
+            name: ent.file_name().to_string_lossy().into_owned(),
+            path: ent.path().to_string_lossy().into_owned(),
+            is_dir: md.is_dir(),
+            size: if md.is_file() { md.len() } else { 0 },
+        });
+    }
+    out.sort_by(|a, b| match (a.is_dir, b.is_dir) {
+        (true, false) => std::cmp::Ordering::Less,
+        (false, true) => std::cmp::Ordering::Greater,
+        _ => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
+    });
+    Ok(out)
+}
+
+/// Root to seed the in-app browser with — the engine's own home dir (falls
+/// back to "/"). Mirrors the desktop branch of the Tauri command exactly;
+/// there's no Android-style removable-volume enumeration to do here.
+pub fn storage_roots() -> Vec<String> {
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .unwrap_or_else(|_| "/".to_string());
+    vec![home]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_dir_sorts_dirs_first_then_files_case_insensitive() {
+        let tmp = std::env::temp_dir().join(format!("ps5_engine_lf_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(tmp.join("Zsub")).unwrap();
+        std::fs::create_dir_all(tmp.join("alpha")).unwrap();
+        std::fs::write(tmp.join("b.txt"), b"hello").unwrap();
+        std::fs::write(tmp.join("A.bin"), b"xy").unwrap();
+
+        let out = list_dir(tmp.to_str().unwrap()).unwrap();
+        let names: Vec<&str> = out.iter().map(|e| e.name.as_str()).collect();
+        // Directories first (alpha, Zsub — case-insensitive), then files
+        // (A.bin, b.txt — case-insensitive).
+        assert_eq!(names, vec!["alpha", "Zsub", "A.bin", "b.txt"]);
+        assert!(out[0].is_dir);
+        assert_eq!(out[0].size, 0);
+        let btxt = out.iter().find(|e| e.name == "b.txt").unwrap();
+        assert!(!btxt.is_dir);
+        assert_eq!(btxt.size, 5);
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn list_dir_errors_on_missing_dir() {
+        let r = list_dir("/no/such/ps5upload-test-dir-xyz");
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn storage_roots_returns_at_least_one_entry() {
+        let roots = storage_roots();
+        assert!(!roots.is_empty(), "expected at least the home dir / \"/\"");
+    }
+}


### PR DESCRIPTION
## Description

A prior PR (#188, capability gating) hid the Upload screen entirely in
the browser web UI because at the time no browser session could pick a
file *or* start a transfer. That over-corrected: `startTransferFile`/
`startTransferDir` always operated on a plain local path string that the
**engine process itself** reads via `std::fs` — true for the bundled
desktop engine (same machine as the UI) and equally true for a
Dockerized engine (the container's own filesystem, e.g. `-v
/host/games:/data/games`). The desktop file dialog only ever existed to
*produce that path string*; it was never a file-content upload
mechanism. A user who mounts files into the container has always had
files the engine can transfer — the browser UI just had no way to reach
that capability: no picker, and the transfer-start commands weren't
wired into `browserInvoke.ts` at all.

This restores Upload in the browser, scoped to what the engine can
already do without any new transfer machinery.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Changes Made

- **`engine/crates/ps5upload-engine/src/local_fs.rs`** (new): `list_dir`/`storage_roots`, ported verbatim from the non-Android branch of the Tauri `local_fs.rs` command (which has zero Tauri-specific APIs to begin with — pure `std::fs`). Two new routes in `lib.rs`: `GET /api/local/list-dir`, `GET /api/local/storage-roots` — these browse the **engine's own** filesystem, distinct from the existing PS5-side `/api/ps5/list-dir`. Brought the two existing unit tests across unchanged.
- **`client/src/api/localFs.ts`**: now imports `invoke` from `invokeLogged` instead of raw `@tauri-apps/api/core`, so its 4 calls flow through `browserInvoke` in a browser session — reusing the existing `LocalPathPicker` UI (built for Android's scoped-storage problem) with **zero component changes**.
- **`client/src/lib/browserInvoke.ts`**: added `local_list_dir`/`local_storage_roots` (proxied to the new routes), `storage_access_granted`/`request_storage_access` (answered directly client-side — no scoped-storage concept in a browser, matching desktop's own always-granted/no-op behavior, no network round-trip needed), and `transfer_file`/`transfer_dir`/`transfer_dir_reconcile` (forwarding the TS wrapper's already-correct snake_case `req` body verbatim to the existing `/api/transfer/*` routes — no new transfer logic, no field remapping).
- **`client/src/screens/Upload/index.tsx`**: `handleChooseFile`/`handleChooseFolder`'s inline picker gate (previously `isAndroid() ? ... : openDialog(...)`) now also routes through the in-app browser when `!isTauriEnv()`.
- **`client/src/state/upload.ts`**: archive (`.zip`/`.7z`/`.rar`) picks in browser mode short-circuit with a clear "not available in the browser yet" message instead of hitting `BrowserUnsupportedError` mid-inspect — the archive-inspect step streams progress over a Tauri `Channel` with no browser equivalent yet (tracked as a follow-up; not blocking plain file/folder upload).
- **`client/src/layout/Sidebar.tsx`** / **`client/src/App.tsx`**: reverted Upload's `hideInBrowser`/`NativeOnlyRoute` from #188. **Payloads stays hidden** — unrelated to this fix, it caches release downloads to a local Tauri-only dir even for its "repo-fetched" catalogue tab.
- **`README.md`/`FAQ.md`**: updated the self-hosted web UI FAQ entries (written in #189, made stale by #188) to reflect Upload now working in the browser, emphasizing the picker browses the *engine's* filesystem, not the browser's own machine, plus the archive/queue-persistence caveats.

No new transfer machinery, and the security posture is unchanged: `POST /api/transfer/file`/`/dir` already accept and read *any* engine-reachable path with no allowlist (true before this PR, for the Tauri-only case) — the new listing routes make the filesystem enumerable but don't expand what the engine could already be asked to read.

## Documentation Updates

**Did you update the documentation?** [x] Yes [ ] No

Files: `README.md`, `FAQ.md` — see above.

## Testing

- [x] `npm run validate` equivalent: `typecheck`, `lint`, full Vitest suite (72 files / 782 tests), `npm run build:vite` — all green.
- [ ] `npm run coverage`
- [ ] Built PS5 payload successfully
- [ ] Cross-platform CI target checks passed
- [ ] Tested on real PS5 hardware
- [ ] Tested desktop app
- [x] Verified all example commands in docs work — `cargo build`/`cargo build --features webui`/`cargo test --workspace`/`cargo fmt --check`/`cargo clippy` (both feature configs) all clean; ran the actual engine binary (with the `webui` feature and a real built frontend) against a fake container filesystem (`HOME` pointed at a scratch dir with nested folders/files) and verified: `/api/local/storage-roots` reflects the engine's `$HOME`, `/api/local/list-dir` lists and navigates correctly (dirs-first, case-insensitive), the SPA still serves `/` and deep-links like `/upload` resolve, and `POST /api/transfer/file`/`/dir` accept the exact JSON body `browserInvoke.ts` now sends and return a `202` + `job_id`.
- [x] Tested edge cases and error handling — confirmed the archive-pick guard triggers cleanly instead of throwing; confirmed Payloads' `hideInBrowser`/`NativeOnlyRoute` are untouched and still hide that screen.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation to reflect my changes
- [x] My changes generate no new warnings
- [ ] I have tested my changes on PS5 hardware (or simulated environment)
- [ ] All example code in documentation has been tested and works

## Additional Notes

Archive upload (`.zip`/`.7z`/`.rar`) in the browser is a deliberate follow-up, not included here: the underlying `transfer_zip`/`transfer_7z`/`transfer_rar` cases would be trivial (identical shape to `transfer_file`), but the streaming inspect (`zip_inspect_stream`/`sevenz_inspect_stream`) that runs on pick needs a genuine browser-side SSE consumer (parsing the engine's existing `progress`/`done`/`error` named-SSE-event frames and driving the caller's `Channel.onmessage` manually) — kept separate so this PR ships and is verifiable without that risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)