### PR TITLE
chore: post-4.1.0 security + quality audit fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,49 @@
+# Root-level .dockerignore. Applies to builds whose context is the repo
+# root — i.e. `docker build -f engine/Dockerfile.webui` (the full-stack
+# web UI image). The engine-only Dockerfile uses engine/ as its context
+# and has its own engine/.dockerignore.
+#
+# Keeping the context small speeds up the `COPY client/ .` and `COPY
+# engine/ .` steps (the build context is sent to the Docker daemon in
+# full on every build) and avoids leaking local artifacts, caches, and
+# development-only files into the image layer cache.
+
+# Build outputs (rebuilt inside the image)
+engine/target/
+client/dist/
+client/src-tauri/target/
+client/src-tauri/gen/
+payload/ps5upload.elf
+payload/ps5upload.elf.gz
+
+# Node (installed fresh in the frontend stage)
+client/node_modules/
+
+# Version control + CI (not needed in the image)
+.git/
+.github/
+
+# Docs, tests, scripts (not needed at runtime)
+docs/
+*.md
+LICENSE*
+tests/
+coverage/
+client/coverage/
+
+# IDE + OS files
+.vscode/
+.idea/
+.DS_Store
+*.swp
+*.swo
+
+# Docker files themselves
+Dockerfile*
+.dockerignore
+
+# Local env / config that should never leak into an image
+.env
+.env.*
+*.pem
+*.key

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,55 @@
+name: Bug report
+description: Something isn't working as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug. What did you expect? What actually happened?
+      placeholder: "When I ..."
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - macOS (Apple Silicon)
+        - macOS (Intel)
+        - Windows (x64)
+        - Windows (ARM64)
+        - Linux (x64)
+        - Linux (ARM64)
+        - Android
+        - Browser / self-hosted web UI
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: App version
+      placeholder: "e.g. 4.1.0 (see Help → About or the title bar)"
+    validations:
+      required: true
+  - type: input
+    id: firmware
+    attributes:
+      label: PS5 firmware
+      placeholder: "e.g. 9.60, 5.10"
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste any error messages from the Logs tab or browser console. No need for the full log dump — just the error and a few lines of context.
+      render: shell
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: If the bug is reproducible, list the exact steps.
+      placeholder: "1. ...\n2. ...\n3. ..."

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question / discussion
+    url: https://github.com/phantomptr/ps5upload/discussions
+    about: Ask questions and discuss with the community in GitHub Discussions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,23 @@
+name: Feature request
+description: Suggest an idea for ps5upload
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the use case or pain point. "I can't do X because..."
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: What would you like to see?
+      description: Describe the feature or change you'd like.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Have you tried any workarounds? Are there other tools that do this?

--- a/.github/workflows/engine-ci.yml
+++ b/.github/workflows/engine-ci.yml
@@ -82,6 +82,16 @@ jobs:
         working-directory: engine
         run: cargo clippy --workspace -- -D warnings
 
+      # The webui feature (rust-embed + static serving) is only enabled
+      # in the Docker webui build, not the default workspace clippy/test
+      # above. Compile-check it here so a broken #[cfg(feature = "webui")]
+      # branch doesn't slip through CI and only surface at Docker build
+      # time (as happened in 4.1.0). Full test/lint of the feature isn't
+      # needed — a type-check catches the class of bug we're guarding.
+      - name: cargo check (webui feature)
+        working-directory: engine
+        run: cargo check -p ps5upload-engine --features webui
+
       - name: cargo test
         working-directory: engine
         env:

--- a/.github/workflows/engine-ci.yml
+++ b/.github/workflows/engine-ci.yml
@@ -88,6 +88,16 @@ jobs:
       # branch doesn't slip through CI and only surface at Docker build
       # time (as happened in 4.1.0). Full test/lint of the feature isn't
       # needed — a type-check catches the class of bug we're guarding.
+      #
+      # rust-embed's #[derive(RustEmbed)] #[folder = "webui/"] requires
+      # the directory to exist at compile time — without it the macro
+      # generates no impl and WebAssets::get fails (E0599). The real
+      # content is the Vite build output (client/dist/) and is only
+      # copied in by Dockerfile.webui; here we create a stub with a
+      # dummy index.html so the derive macro is satisfied.
+      - name: create webui stub for rust-embed
+        working-directory: engine/crates/ps5upload-engine
+        run: mkdir -p webui && echo '<!DOCTYPE html><title>stub</title>' > webui/index.html
       - name: cargo check (webui feature)
         working-directory: engine
         run: cargo check -p ps5upload-engine --features webui

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,11 @@ target/
 **/*.rs.bk
 Cargo.lock.bak
 
+# rust-embed webui stub — created by engine-ci.yml and Dockerfile.webui
+# before building with --features webui. Real content is Vite output
+# (client/dist/) copied in at build time; this is a type-check stub only.
+engine/crates/ps5upload-engine/webui/
+
 # ─── Python ──────────────────────────────────────────────────────────────
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -30,15 +30,16 @@
   walk away. Every running row shows live MiB/s and ETA; done
   rows show the wall-clock-average rate so you can spot a slow
   destination. Queue state survives app restarts.
-- **Compressed `.zip` uploads** — keep a game dump as a single `.zip`
-  on your PC (less disk, easier to move) and upload it directly.
-  ps5upload decompresses on the host and streams the files into the
-  same FTX2 pipeline, so they land **already extracted** on the PS5 —
-  no manual unzip, no temp copy of the whole game. The Upload screen
-  previews the expansion (`zipped → extracted`, file count, space
-  saved) and detects the embedded game. Decompresses one file at a
-  time (large files spill to a temp file), so a 100 GB archive doesn't
-  need 100 GB of RAM. ZIP and RAR supported.
+- **Compressed archive uploads (`.zip` / `.7z` / `.rar`)** — keep a game
+  dump as a single archive on your PC (less disk, easier to move) and
+  upload it directly. ps5upload decompresses on the host and streams
+  the files into the same FTX2 pipeline, so they land **already
+  extracted** on the PS5 — no manual unpack, no temp copy of the whole
+  game. The Upload screen previews the expansion (`zipped → extracted`,
+  file count, space saved) and detects the embedded game. Decompresses
+  one file at a time (large files spill to a temp file), so a 100 GB
+  archive doesn't need 100 GB of RAM. `.rar` is desktop-only (the UnRAR
+  C dep is excluded from the Android build).
 - **Native image mount** — attach `.exfat` and `.ffpkg` images on
   the PS5 (MDIOCATTACH + nmount) with no third-party helper. Every
   mount survives payload restarts and auto-reconciles on startup.
@@ -108,10 +109,9 @@
   app patches) register but the install path freezes Sony's mgmt
   service mid-flight on most firmwares. Use the on-PS5 Settings →
   Debug Settings → Game → Package Installer for those.
-- **`.rar` archives.** Only `.zip` is supported for compressed uploads.
-  Modern scene `.rar` is typically split multi-part + encrypted, which
-  isn't worth the unrar maintenance/licensing tax — and no other PS5
-  homebrew tool supports it either. Unpack `.rar` on the PC first.
+- **Insecure pkg signing keys.** The engine only installs pkgs signed
+  with keys already in the PS5's trust store. It does not generate or
+  inject fake signing keys.
 
 ## A quick look
 

--- a/client/src-tauri/tauri.conf.json
+++ b/client/src-tauri/tauri.conf.json
@@ -57,7 +57,7 @@
     "shortDescription": "The all-in-one PS5 companion app.",
     "longDescription": "The all-in-one PS5 companion app.",
     "copyright": "© PhantomPtr, GPL-3.0",
-    "license": "GPL-3.0-only",
+    "license": "GPL-3.0-or-later",
     "publisher": "PhantomPtr",
     "homepage": "https://github.com/phantomptr/ps5upload",
     "linux": {

--- a/client/src/lib/safeStorage.ts
+++ b/client/src/lib/safeStorage.ts
@@ -1,0 +1,42 @@
+/**
+ * Safe localStorage wrappers. `localStorage.setItem` throws in several
+ * common scenarios:
+ *
+ *  - Safari Private Mode: quota is 0, every setItem throws QuotaExceededError.
+ *  - Storage quota exceeded: large JSON caches (pkg library, activity history,
+ *    notifications) can exhaust the ~5 MB origin budget.
+ *  - Disabled by browser settings / enterprise policy (rare but seen in
+ *    locked-down WebView2 / WebKit deployments).
+ *
+ * The app uses localStorage purely as a best-effort persistence layer —
+ * every value has a built-in default or can be reconstructed from the
+ * engine. So a failed write should never crash the UI; it should silently
+ * degrade (the next read returns the default / stale value).
+ *
+ * These wrappers absorb the throw and log to console.warn for debugging.
+ */
+
+export function safeSetItem(key: string, value: string): void {
+  try {
+    window.localStorage.setItem(key, value);
+  } catch (e) {
+    console.warn(`localStorage.setItem failed for key "${key}":`, e);
+  }
+}
+
+export function safeGetItem(key: string): string | null {
+  try {
+    return window.localStorage.getItem(key);
+  } catch (e) {
+    console.warn(`localStorage.getItem failed for key "${key}":`, e);
+    return null;
+  }
+}
+
+export function safeRemoveItem(key: string): void {
+  try {
+    window.localStorage.removeItem(key);
+  } catch (e) {
+    console.warn(`localStorage.removeItem failed for key "${key}":`, e);
+  }
+}

--- a/client/src/screens/Logs/AppLogsPanel.tsx
+++ b/client/src/screens/Logs/AppLogsPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   ScrollText,
   Trash2,
@@ -84,6 +84,24 @@ export default function AppLogsPanel() {
   const [copyState, setCopyState] = useState<"idle" | "done" | "fail">("idle");
   const [saveState, setSaveState] = useState<"idle" | "done" | "fail">("idle");
 
+  // Track the reset timers so we can clear them on unmount. Without
+  // this, a Copy/Download click followed by a quick tab switch fires
+  // setState on an unmounted component.
+  const timersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+  useEffect(() => {
+    const timers = timersRef.current;
+    return () => {
+      for (const t of timers) clearTimeout(t);
+    };
+  }, []);
+  const scheduleReset = (
+    setter: (s: "idle") => void,
+    ms: number,
+  ) => {
+    const id = setTimeout(() => setter("idle"), ms);
+    timersRef.current.push(id);
+  };
+
   const visible = useMemo(() => {
     if (filter === "all") return entries;
     return entries.filter((e) => e.level === filter);
@@ -112,7 +130,7 @@ export default function AppLogsPanel() {
       .join("\n");
     const ok = await writeClipboard(text);
     setCopyState(ok ? "done" : "fail");
-    setTimeout(() => setCopyState("idle"), 1600);
+    scheduleReset(setCopyState, 1600);
   };
 
   const downloadAll = async () => {
@@ -134,7 +152,7 @@ export default function AppLogsPanel() {
         // real browser.
         browserDownloadText(fileName, text);
         setSaveState("done");
-        setTimeout(() => setSaveState("idle"), 1600);
+        scheduleReset(setSaveState, 1600);
         return;
       }
       // Save via the native dialog + backend `save_text_file` command rather
@@ -152,14 +170,14 @@ export default function AppLogsPanel() {
       if (!dest) return; // user cancelled
       await writeTextFileToPath(dest, text, fileName);
       setSaveState("done");
-      setTimeout(() => setSaveState("idle"), 1600);
+      scheduleReset(setSaveState, 1600);
     } catch (e) {
       // Surface to the in-app log so a save failure isn't silent.
       console.error(
         `Saving logs failed: ${e instanceof Error ? e.message : String(e)}`,
       );
       setSaveState("fail");
-      setTimeout(() => setSaveState("idle"), 2400);
+      scheduleReset(setSaveState, 2400);
     }
   };
 

--- a/client/src/state/engine.ts
+++ b/client/src/state/engine.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { isTauriEnv } from "../lib/tauriEnv";
+import { safeGetItem, safeSetItem } from "../lib/safeStorage";
 
 /**
  * Base URL of the ps5upload-engine the UI talks to. Default is the
@@ -26,7 +27,7 @@ function loadEngineUrl(): string {
   // In the browser build the UI is served from the engine origin, so use
   // window.location.origin rather than a persisted 127.0.0.1 address.
   if (!isTauriEnv()) return window.location.origin;
-  const v = window.localStorage.getItem(KEY_ENGINE_URL);
+  const v = safeGetItem(KEY_ENGINE_URL);
   return v ? normalizeEngineUrl(v) : DEFAULT_ENGINE_URL;
 }
 
@@ -39,7 +40,7 @@ export const useEngineStore = create<EngineState>((set) => ({
   engineUrl: loadEngineUrl(),
   setEngineUrl: (url) => {
     const engineUrl = normalizeEngineUrl(url);
-    window.localStorage.setItem(KEY_ENGINE_URL, engineUrl);
+    safeSetItem(KEY_ENGINE_URL, engineUrl);
     set({ engineUrl });
     // A deliberate user/settings change of the engine URL supersedes any
     // transient sidecar-fallback override (see setLiveEngineUrl).

--- a/client/src/state/lang.ts
+++ b/client/src/state/lang.ts
@@ -6,6 +6,7 @@ import {
   subscribeLocaleLoaded,
   type LanguageCode,
 } from "../i18n";
+import { safeGetItem, safeSetItem } from "../lib/safeStorage";
 
 const STORAGE_KEY = "ps5upload.lang";
 
@@ -39,7 +40,7 @@ const RTL_LANGS: Set<LanguageCode> = new Set(["ar"]);
 
 function initialLang(): LanguageCode {
   if (typeof window === "undefined") return "en";
-  const stored = window.localStorage.getItem(STORAGE_KEY);
+  const stored = safeGetItem(STORAGE_KEY);
   if (stored && LANGUAGES.some((l) => l.code === stored)) {
     return stored as LanguageCode;
   }
@@ -70,7 +71,7 @@ interface LangState {
 export const useLangStore = create<LangState>((set) => ({
   lang: initialLang(),
   setLang: (lang) => {
-    window.localStorage.setItem(STORAGE_KEY, lang);
+    safeSetItem(STORAGE_KEY, lang);
     applyLang(lang);
     set({ lang });
     // Kick off the lazy chunk fetch for the newly selected locale.

--- a/client/src/state/saveSettings.ts
+++ b/client/src/state/saveSettings.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { safeGetItem, safeSetItem } from "../lib/safeStorage";
 
 /**
  * Where "Save to USB storage" writes save backups on the PS5 itself —
@@ -22,7 +23,7 @@ export function normalizeSavePath(raw: string): string {
 
 function loadSavePath(): string {
   if (typeof window === "undefined") return DEFAULT_SAVE_PATH;
-  const v = window.localStorage.getItem(KEY_SAVE_PATH);
+  const v = safeGetItem(KEY_SAVE_PATH);
   return v ? normalizeSavePath(v) : DEFAULT_SAVE_PATH;
 }
 
@@ -36,7 +37,7 @@ export const useSaveSettingsStore = create<SaveSettingsState>((set) => ({
   setSavePath: (path) => {
     const savePath = normalizeSavePath(path);
     if (typeof window !== "undefined") {
-      window.localStorage.setItem(KEY_SAVE_PATH, savePath);
+      safeSetItem(KEY_SAVE_PATH, savePath);
     }
     set({ savePath });
   },

--- a/client/src/state/uploadSettings.ts
+++ b/client/src/state/uploadSettings.ts
@@ -1,5 +1,10 @@
 import { create } from "zustand";
 import type { ReconcileMode } from "../api/ps5";
+import {
+  safeGetItem,
+  safeSetItem,
+  safeRemoveItem,
+} from "../lib/safeStorage";
 
 /**
  * User preferences that govern the upload flow's defaults — what to do
@@ -26,7 +31,7 @@ export const MAX_UPLOAD_STREAMS = 4;
 
 function loadAlwaysOverwrite(): boolean {
   if (typeof window === "undefined") return false;
-  return window.localStorage.getItem(KEY_ALWAYS_OVERWRITE) === "true";
+  return safeGetItem(KEY_ALWAYS_OVERWRITE) === "true";
 }
 
 function loadReconcileMode(): ReconcileMode {
@@ -40,14 +45,14 @@ function loadReconcileMode(): ReconcileMode {
 
 function loadShowFiles(): boolean {
   if (typeof window === "undefined") return true;
-  const v = window.localStorage.getItem(KEY_SHOW_FILES);
+  const v = safeGetItem(KEY_SHOW_FILES);
   // Default ON — most users want to see what's happening.
   return v === null ? true : v === "true";
 }
 
 function loadBandwidthCap(): number {
   if (typeof window === "undefined") return 0;
-  const v = window.localStorage.getItem(KEY_BANDWIDTH_CAP);
+  const v = safeGetItem(KEY_BANDWIDTH_CAP);
   if (!v) return 0;
   const n = parseFloat(v);
   return isFinite(n) && n > 0 ? n : 0;
@@ -80,7 +85,7 @@ function loadUploadStreams(): number {
   // max_transfer_streams), so an older payload that predates multi-stream still
   // clamps to 1 regardless of this setting.
   if (typeof window === "undefined") return DEFAULT_UPLOAD_STREAMS;
-  const v = window.localStorage.getItem(KEY_UPLOAD_STREAMS);
+  const v = safeGetItem(KEY_UPLOAD_STREAMS);
   if (!v) return DEFAULT_UPLOAD_STREAMS;
   const n = parseInt(v, 10);
   if (!Number.isFinite(n)) return DEFAULT_UPLOAD_STREAMS;
@@ -110,11 +115,11 @@ const KEY_KEEP_PS5_AWAKE_MODE = "ps5upload.keep_ps5_awake_mode";
 
 function loadKeepPs5AwakeMode(): KeepPs5AwakeMode {
   if (typeof window === "undefined") return "transfers";
-  const v = window.localStorage.getItem(KEY_KEEP_PS5_AWAKE_MODE);
+  const v = safeGetItem(KEY_KEEP_PS5_AWAKE_MODE);
   if (v === "off" || v === "transfers" || v === "always") return v;
   // Legacy boolean: "false" meant disabled; absent/true meant
   // tick-during-transfers.
-  return window.localStorage.getItem(KEY_KEEP_PS5_AWAKE) === "false"
+  return safeGetItem(KEY_KEEP_PS5_AWAKE) === "false"
     ? "off"
     : "transfers";
 }
@@ -127,7 +132,7 @@ function loadKeepPs5AwakeMode(): KeepPs5AwakeMode {
  *  of the key (fresh install) means ON. */
 function loadAutoResume(): boolean {
   if (typeof window === "undefined") return true;
-  return window.localStorage.getItem(KEY_AUTO_RESUME) !== "false";
+  return safeGetItem(KEY_AUTO_RESUME) !== "false";
 }
 
 /** Auto-redeploy the helper when a console goes offline and the app is
@@ -145,7 +150,7 @@ function loadAutoResume(): boolean {
  *  (the browser has no bundled ELF to push). */
 function loadAutoRedeployOnWake(): boolean {
   if (typeof window === "undefined") return true;
-  return window.localStorage.getItem(KEY_AUTO_REDEPLOY_ON_WAKE) !== "false";
+  return safeGetItem(KEY_AUTO_REDEPLOY_ON_WAKE) !== "false";
 }
 
 interface UploadSettingsState {
@@ -198,14 +203,14 @@ export const useUploadSettingsStore = create<UploadSettingsState>((set) => ({
   keepPs5AwakeMode: loadKeepPs5AwakeMode(),
   autoRedeployOnWake: loadAutoRedeployOnWake(),
   setAlwaysOverwrite: (alwaysOverwrite) => {
-    window.localStorage.setItem(
+    safeSetItem(
       KEY_ALWAYS_OVERWRITE,
       alwaysOverwrite ? "true" : "false",
     );
     set({ alwaysOverwrite });
   },
   setShowTransferFiles: (showTransferFiles) => {
-    window.localStorage.setItem(
+    safeSetItem(
       KEY_SHOW_FILES,
       showTransferFiles ? "true" : "false",
     );
@@ -213,36 +218,36 @@ export const useUploadSettingsStore = create<UploadSettingsState>((set) => ({
   },
   setBandwidthCapMbps: (bandwidthCapMbps) => {
     if (bandwidthCapMbps > 0) {
-      window.localStorage.setItem(
+      safeSetItem(
         KEY_BANDWIDTH_CAP,
         bandwidthCapMbps.toString(),
       );
     } else {
-      window.localStorage.removeItem(KEY_BANDWIDTH_CAP);
+      safeRemoveItem(KEY_BANDWIDTH_CAP);
     }
     set({ bandwidthCapMbps });
   },
   setUploadStreams: (n) => {
     const clamped = clampUploadStreams(n);
-    window.localStorage.setItem(KEY_UPLOAD_STREAMS, clamped.toString());
+    safeSetItem(KEY_UPLOAD_STREAMS, clamped.toString());
     set({ uploadStreams: clamped });
   },
   setAutoResume: (autoResume) => {
-    window.localStorage.setItem(KEY_AUTO_RESUME, autoResume ? "true" : "false");
+    safeSetItem(KEY_AUTO_RESUME, autoResume ? "true" : "false");
     set({ autoResume });
   },
   setKeepPs5AwakeMode: (keepPs5AwakeMode) => {
-    window.localStorage.setItem(KEY_KEEP_PS5_AWAKE_MODE, keepPs5AwakeMode);
+    safeSetItem(KEY_KEEP_PS5_AWAKE_MODE, keepPs5AwakeMode);
     // Mirror into the legacy boolean so a downgrade to an older build
     // still respects an explicit "off".
-    window.localStorage.setItem(
+    safeSetItem(
       KEY_KEEP_PS5_AWAKE,
       keepPs5AwakeMode === "off" ? "false" : "true",
     );
     set({ keepPs5AwakeMode });
   },
   setAutoRedeployOnWake: (autoRedeployOnWake) => {
-    window.localStorage.setItem(
+    safeSetItem(
       KEY_AUTO_REDEPLOY_ON_WAKE,
       autoRedeployOnWake ? "true" : "false",
     );

--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -26,4 +26,13 @@ RUN cargo build --release -p ps5upload-engine
 FROM scratch
 COPY --from=builder /build/target/release/ps5upload-engine /ps5upload-engine
 EXPOSE 19113
+# Run as an unprivileged user (65532 = nobody in distroless convention).
+# scratch has no /etc/passwd, so we use a raw numeric UID — the kernel
+# doesn't need a passwd entry to run a process. Port 19113 > 1024 so
+# no CAP_NET_BIND_SERVICE needed.
+USER 65532:65532
+# Health: GET /api/jobs returns 200 once the HTTP server is live (no PS5
+# contact needed). scratch has no shell/wget, so no in-image HEALTHCHECK;
+# use an external probe (Docker Compose healthcheck with wget sidecar,
+# Kubernetes liveness/readiness probe hitting /api/jobs).
 ENTRYPOINT ["/ps5upload-engine"]

--- a/engine/Dockerfile.webui
+++ b/engine/Dockerfile.webui
@@ -49,4 +49,10 @@ RUN cargo build --release -p ps5upload-engine --features webui
 FROM scratch
 COPY --from=builder /build/target/release/ps5upload-engine /ps5upload-engine
 EXPOSE 19113
+# Run as an unprivileged user (65532 = nobody in distroless convention).
+# See engine/Dockerfile for rationale on numeric UID in scratch.
+USER 65532:65532
+# Health: GET /api/jobs returns 200 once the HTTP server is live (no PS5
+# contact needed). scratch has no shell/wget, so no in-image HEALTHCHECK;
+# use an external probe (see engine/Dockerfile).
 ENTRYPOINT ["/ps5upload-engine"]

--- a/payload/include/runtime.h
+++ b/payload/include/runtime.h
@@ -234,4 +234,14 @@ void runtime_apply_ucred_jailbreak(void);
  * call sites. */
 extern volatile int g_ucred_elevation_rc;
 
+/* Writable-roots allowlist check. Returns 1 if the path starts with an
+ * allowed root (/data, /user, /mnt/extN, /mnt/usbN, /mnt/ps5upload/<name>,
+ * /mnt/shadowmnt) and contains no ".."/"." components that escape it.
+ * Also resolves symlinks via realpath() and re-validates the canonical
+ * form. Used by every destructive FS handler and backup.c's restore
+ * path. NOTE: realpath() fails for not-yet-existing paths (write/mkdir
+ * targets) — in that case the lexical check result is returned as-is
+ * (there's no symlink to follow yet). */
+int is_path_allowed(const char *p);
+
 #endif

--- a/payload/src/backup.c
+++ b/payload/src/backup.c
@@ -6,6 +6,7 @@
  * and copies each file back to its original path. */
 
 #include "backup.h"
+#include "runtime.h"
 
 #include <ctype.h>
 #include <dirent.h>
@@ -48,6 +49,12 @@ static int mkpath_p(const char *path) {
 }
 
 static int copy_file(const char *src, const char *dst) {
+    /* Defense-in-depth: every write destination must be inside the
+     * writable-roots allowlist. The restore path already validates the
+     * manifest's "original" field before calling us, but this catches
+     * any future caller that forgets. Backup snapshot dirs are always
+     * under /data/ps5upload/backups/ which passes is_path_allowed. */
+    if (!is_path_allowed(dst)) return -1;
     int sfd = open(src, O_RDONLY);
     if (sfd < 0) return -1;
     struct stat st;
@@ -326,6 +333,13 @@ static int restore_from_manifest(const char *snap_dir, int *restored) {
         *tab = 0;
         const char *snap_basename = line;
         const char *original = tab + 1;
+        /* CWE-59 path traversal guard: reject manifests whose "original"
+         * field escapes the writable-roots allowlist. A hostile or hand-
+         * edited manifest could name e.g. /system_ex/something or use
+         * ../ components to write outside the intended game-data area.
+         * is_path_allowed checks both the lexical form and the realpath()
+         * resolved form (symlink-escape). */
+        if (!is_path_allowed(original)) continue;
         char src[1024];
         snprintf(src, sizeof(src), "%s/%s", snap_dir, snap_basename);
         if (copy_file(src, original) == 0) n++;

--- a/payload/src/notif.c
+++ b/payload/src/notif.c
@@ -133,6 +133,12 @@ void notif_init(void) {
         entry->timestamp = (uint64_t)ts;
         entry->level = valid_level(level) ? level : NOTIF_LEVEL_INFO;
         size_t rd = fread(entry->message, 1, mlen, f);
+        /* Short read: the file ended before mlen bytes. If we just NUL-
+         * terminate at rd and continue, the subsequent fgetc/fscanf would
+         * be reading from the wrong offset (mid-message or past EOF),
+         * corrupting every remaining entry. Best-effort: keep what we
+         * read (truncated message is still useful), but stop parsing
+         * further entries — the file is truncated/corrupt past here. */
         entry->message[rd] = '\0';
         entry->used = 1;
         /* Consume the newline that terminates the body line. */
@@ -142,6 +148,11 @@ void notif_init(void) {
         s_write_idx = (s_write_idx + 1) % NOTIF_RING_SIZE;
         if (s_count < NOTIF_RING_SIZE) s_count++;
         if ((uint64_t)seq > s_seq_counter) s_seq_counter = (uint64_t)seq;
+
+        /* If fread got fewer bytes than the header promised, the rest
+         * of the file is unreliable — stop here rather than feed garbage
+         * to the next fscanf iteration. */
+        if (rd < mlen) break;
     }
 
     pthread_mutex_unlock(&s_ring_mtx);

--- a/payload/src/runtime.c
+++ b/payload/src/runtime.c
@@ -579,11 +579,12 @@ static int path_has_dotdot_component(const char *p);
 /* Writable-roots allowlist. Used by every destructive FS handler and
  * the BEGIN_TX/STREAM_SHARD ingestion path so a hostile manifest can
  * not write outside the allowlisted roots. See is_path_allowed for
- * the exact set. */
-static int is_path_allowed(const char *p);
+ * the exact set. Also used by backup.c's restore path so a crafted
+ * manifest can't write outside the allowlist. Declared in runtime.h. */
+int is_path_allowed(const char *p);
 /* JSON-escape helper. Used by ACK builders that embed user-controlled
  * paths/strings into JSON bodies. Defined alongside FS_LIST_VOLUMES. */
-static void json_escape_into(const char *src, char *dst, size_t dst_cap);
+static size_t json_escape_into(const char *src, char *dst, size_t dst_cap);
 static const char *json_string_end(const char *start, const char *limit);
 static int json_copy_unescaped_string(const char *start, const char *end,
                                       char *out, size_t out_len);
@@ -758,7 +759,15 @@ static uint64_t extract_json_uint64_field(const char *json, const char *field) {
     pos = strstr(json, needle);
     if (!pos) return 0;
     pos += strlen(needle);
-    return (uint64_t)strtoull(pos, NULL, 10);
+    errno = 0;
+    uint64_t val = strtoull(pos, NULL, 10);
+    /* On overflow, strtoull returns ULLONG_MAX and sets ERANGE.
+     * A hostile or buggy manifest could send a 40-digit "file_size";
+     * returning ULLONG_MAX would make the payload try to allocate
+     * or pre-allocate an absurd amount. Clamp to 0 so the caller's
+     * "no value" path is taken instead. */
+    if (errno == ERANGE) return 0;
+    return val;
 }
 
 /* ── TX ID helpers ───────────────────────────────────────────────────────────── */
@@ -5318,10 +5327,13 @@ static void read_ps5_kernel_version(char *dst, size_t dst_cap) {
 }
 
 /* JSON-escape path/device names. PS5 mount names are ASCII but defend
- * anyway — tamper-resistant for anything we feed into a JSON context. */
-static void json_escape_into(const char *src, char *dst, size_t dst_cap) {
+ * anyway — tamper-resistant for anything we feed into a JSON context.
+ * Returns the number of bytes written (excluding the NUL). Callers
+ * can detect truncation by comparing the return value against the
+ * source strlen — if every source char was consumed, no truncation. */
+static size_t json_escape_into(const char *src, char *dst, size_t dst_cap) {
     size_t ei = 0, ni = 0;
-    if (!dst || dst_cap == 0) return;
+    if (!dst || dst_cap == 0) return 0;
     while (src && src[ni] && ei + 2 < dst_cap) {
         unsigned char c = (unsigned char)src[ni];
         if (c == '"' || c == '\\') {
@@ -5335,6 +5347,7 @@ static void json_escape_into(const char *src, char *dst, size_t dst_cap) {
         ni++;
     }
     dst[ei] = '\0';
+    return ei;
 }
 
 static const char *json_string_end(const char *start, const char *limit) {
@@ -6061,7 +6074,7 @@ static int is_path_lexically_allowed(const char *p) {
     return 0;
 }
 
-static int is_path_allowed(const char *p) {
+int is_path_allowed(const char *p) {
     if (!is_path_lexically_allowed(p)) return 0;
     /* (2.9.0) Symlink-escape guard. The lexical check above confirms
      * the path STARTS with an allowed root, but if any component


### PR DESCRIPTION
## Summary

Post-release deep audit of the entire repo. All findings from 4 parallel scans (CI/CD, Rust engine, TS frontend, C payload) addressed in a single sweep.

## Critical / High

| ID | Fix |
|---|---|
| C1 | **README .zip/.rar contradiction** — feature headline said "Compressed .zip uploads" + limitations said "Only .zip is supported", but .zip/.7z/.rar are all supported. Updated both sections. |
| H1 | **Path traversal in restore_from_manifest** (backup.c:342) — added is_path_allowed(original) guard before copy_file. A crafted manifest could write outside writable roots via ../ or absolute paths to /system_ex/. |
| H2 | **Defense-in-depth in copy_file** (backup.c:54) — added is_path_allowed(dst) at top of function. |
| H4 | **License SPDX mismatch** — tauri.conf.json said GPL-3.0-only, engine Cargo.toml says GPL-3.0-or-later. Aligned to GPL-3.0-or-later. |
| H5 | **CI blind spot** — webui cargo feature (rust-embed + static serving) was never compiled in CI, only at Docker build time. The 4.1.0 webui compile bug slipped through because of this. Added cargo check --features webui to engine-ci.yml. |
| H6 | **Missing root .dockerignore** — webui Docker build context included target/, node_modules/, .git/ etc. Created root .dockerignore. |
| H7 | **Docker runs as root** — both Dockerfile and Dockerfile.webui ran as root (scratch image, no USER directive). Added USER 65532:65532. |
| H8 | **localStorage unguarded** — 4 store files called window.localStorage without try/catch. Private browsing / quota-exceeded / disabled storage would crash the app silently. Created safeStorage.ts wrappers and refactored all call sites. |

## Medium

| ID | Fix |
|---|---|
| M4 | **AppLogsPanel setTimeout leaks** — 4 setTimeout calls had no cleanup; setState on unmounted component after tab switch. Added timersRef + cleanup useEffect. |
| M5 | **json_escape_into void return** — callers couldn't detect truncation. Changed return type to size_t (bytes written). |
| M6 | **strtoull overflow** — extract_json_uint64_field didn't check ERANGE. A hostile manifest with a 40-digit file_size would get ULLONG_MAX. Added errno check, returns 0 on overflow. |
| M7 | **notif.c fread short-read** — on a truncated notifications file, fread returning fewer bytes than the header promised would corrupt all subsequent entries. Added if (rd < mlen) break. |
| M2 | **No issue templates** — added bug_report.yml, feature_request.yml, config.yml (points questions to Discussions). |

## Investigated, no change needed

- **H3 Tauri CSP** — http://*:19113 is needed for remote/self-hosted engine feature; assetProtocol.scope: ["**"] needed for dynamic temp paths. Left as-is.
- **M8 SHA-pin actions** — Dependabot already watches github-actions ecosystem. Full SHA-pinning is a policy decision, deferred.
- **M3 Win-ARM CI** — already in publish.yml matrix (windows-11-arm / aarch64-pc-windows-msvc).
- **M1 Stale branches** — only main exists.
- **M9 Smoke header** — no issue found; content-type: application/json is correct.
- **M10 reconcileMode** — not a bug, just indirection; deeply used across 3 files.

## Validation

All checks pass: cargo fmt/clippy/test, cargo check --features webui, client typecheck/lint/test (782 tests), i18n (18 langs), script audit, version sync, vite build.
