### PR TITLE
fix(payload): FW 10+ authid gate (closes #152), reconnect i18n (closes #208)

### DIFF
--- a/client/src/i18n/locales/en.ts
+++ b/client/src/i18n/locales/en.ts
@@ -226,7 +226,7 @@ activity_bar_toggle: "Toggle activity panel",
 
 // Connection screen
 connection_title: "Connect to your PS5",
-connection_description: "Three quick steps before your first upload. You only need to do this once per PS5 boot — the helper stays loaded until the console reboots or goes into rest mode.",
+connection_description: "Three quick steps before your first upload. You only need to do this once per PS5 boot — the helper stays loaded until the console reboots. After rest mode or a network drop the app reconnects on its own (Settings → Upload → “Reconnect automatically after rest mode / network drops”, on by default).",
 connection_step1_title: "Tell the app where your PS5 is",
 connection_step2_title: "Send the PS5Upload helper to your PS5",
 connection_step3_title: "You're ready to upload",
@@ -1841,7 +1841,7 @@ err_install_http_fetch:
 err_install_116f_npxs:
   "PS5 installer rejected this system pkg (0x80B2116F). Sony's installer can't complete system patches (Store updates, Settings) — use Settings → Debug Settings → Game → Package Installer on the PS5 itself for these.",
 err_install_116f_game:
-  "PS5 installer rejected the pkg (0x80B2116F). On FW 9.60 this firmware point is missing the BGFT registers our payload uses; try pushing the latest payload (Connection → Send payload), and if it still fails the pkg may need installing via the PS5's own Debug Settings → Game → Package Installer.",
+  "PS5 installer rejected the pkg (0x80B2116F). On FW 9.60 this firmware point is missing the BGFT registers our payload uses; on FW 10.00+ this is a process-authid mismatch that the latest payload fixes (older payloads init Sony's installer under the wrong authid, leaving it half-wedged — Sony's watchdog then kills the helper ~5s after the reject). Try pushing the latest payload (Connection → Send payload). If it still fails after that, the pkg may need installing via the PS5's own Debug Settings → Game → Package Installer.",
 err_install_1401:
   "PS5's ShellUI install path rejected the request (0x80B21401). Usually paired with another tier failure on FW 9.60 when the firmware point lacks the BGFT registers we depend on. Try the latest payload from Connection → Send payload, or install via the PS5's own Debug Settings panel.",
 err_install_2101:

--- a/engine/crates/ps5upload-core/src/pkg_install.rs
+++ b/engine/crates/ps5upload-core/src/pkg_install.rs
@@ -601,7 +601,10 @@ pub fn err_code_message(code: u32) -> Option<&'static str> {
         // most often because the pkg is a system patch (NPXS-prefix)
         // and the API isn't designed for them, OR because the firmware
         // doesn't expose the BGFT symbols our payload depends on.
-        // Hardware-observed on FW 9.60 when all 3 tiers fail.
+        // Hardware-observed on FW 9.60 when all 3 tiers fail, and on
+        // FW 10.00+ when an outdated payload inits Sony's installer
+        // under the wrong authid (issue #152: the install returns
+        // 0x80B2116F and Sony's watchdog kills the helper ~5s later).
         0x80B2_116F => Some(
             "PS5 installer rejected the request — pkg may be a system patch (use Settings → Debug Settings → Game → Package Installer) or the firmware lacks the BGFT entry points we need",
         ),

--- a/payload/src/bgft.c
+++ b/payload/src/bgft.c
@@ -416,18 +416,24 @@ static int appinst_install_start(const char *url,
      * — which share the global kernel-RW window — can't run at the same time.
      * Innermost lock: taken AFTER sony_api_lock, never before. */
     pthread_mutex_lock(&kernel_rw_lock);
-    /* Firmware-gated install authid — the FW-11 "authority cliff" (matches
-     * elf-arsenal's per-FW method). BELOW FW 11 (5.10/9.60, HW-proven):
-     * ShellCore authid is the gate InstallByPackage's URL pre-flight requires
-     * (other authids → 0x80B22404 for http / 0x80B21106 for file://). AT/ABOVE
-     * FW 11: the content-copy step is gated behind the SYSTEM authid
-     * (== elf-arsenal's JB_AUTHID 0x4801…013); running InstallByPackage under
-     * ShellCore there registers the title but lands NO content — the "hollow"
-     * dead-tile (appmeta present, /user/app empty). fw==0 (unknown) → ShellCore,
-     * the proven default. Both Init and InstallByPackage run under this one
+    /* Firmware-gated install authid — the FW-10 "authority cliff". BELOW
+     * FW 10 (5.10/9.60, HW-proven): ShellCore authid is the gate
+     * InstallByPackage's URL pre-flight requires (other authids →
+     * 0x80B22404 for http / 0x80B21106 for file://). AT/ABOVE FW 10: the
+     * content-copy step AND the IPMI init handshake are gated behind the
+     * SYSTEM authid (== elf-arsenal's JB_AUTHID 0x4801…013); running
+     * sceAppInstUtilInitialize + InstallByPackage under ShellCore on FW 10+
+     * leaves Sony's installer daemon (IPMI) half-wedged — the immediate
+     * InstallByPackage call returns 0x80B2116F, and Sony's installer
+     * watchdog SIGKILLs our process ~5 s later (issue #152: helper dies
+     * after install rejection on FW 10.40). The DPI daemon
+     * (payload/dpi/ezremote_dpi.c) already escalates to SYSTEM_AUTHID
+     * before sceAppInstUtilInitialize on ALL FWs — this matches that.
+     * fw==0 (unknown) → ShellCore, the proven default for the broadest
+     * installed base. Both Init and InstallByPackage run under this one
      * swap window so Sony's IPC handle setup sees the right authid. */
     int fw_major = detect_firmware_major();
-    uint64_t install_authid = (fw_major >= 11)
+    uint64_t install_authid = (fw_major >= 10)
                                   ? PS5_SYSTEM_INSTALL_AUTHID
                                   : PS5_SHELLCORE_AUTHID;
     uint64_t saved_authid = ps5_authid_acquire("InstallByPackage", install_authid);
@@ -439,7 +445,7 @@ static int appinst_install_start(const char *url,
     /* Init Sony's installer subsystem under the chosen authid. The
      * pthread_once guard makes this idempotent across installs; the
      * FIRST install's pthread_once-controlled invocation sets up
-     * Sony's IPC handles correctly (under SYSTEM on FW 11+, exactly as
+     * Sony's IPC handles correctly (under SYSTEM on FW 10+, exactly as
      * elf-arsenal inits from its escalated process). */
     pthread_once(&g_appinst_init_once, appinst_init_locked);
 


### PR DESCRIPTION
## Issue #152 — Helper crashes ~5s after install rejection on FW 10.40

**Root cause:** The authid threshold in `payload/src/bgft.c` was `fw_major >= 11` — use `PS5_SYSTEM_INSTALL_AUTHID` only on FW 11+, `PS5_SHELLCORE_AUTHID` everywhere below. **FW 10.xx has the same SYSTEM-authid gate** for `sceAppInstUtilInitialize` that the code only attributed to FW 11+.

**Mechanism:**
1. On FW 10.40, the in-process install path (`bgft_install_start` → `appinst_install_start`) calls `sceAppInstUtilInitialize` + `sceAppInstUtilInstallByPackage` under **ShellCore authid` (the FW<11 default).
2. Sony's installer daemon (IPMI) rejects this init — it expects `SYSTEM_AUTHID` on FW 10+ (same gate the standalone DPI daemon already knows about; `payload/dpi/ezremote_dpi.c:258` escalates via `jb_escalate_pid` before init on ALL FWs).
3. IPMI state is left half-wedged. The `InstallByPackage` call returns `0x80B2116F`.
4. We restore authid and return -1 cleanly.
5. **~5 seconds later**, Sony's installer watchdog detects the half-wedged IPMI state and SIGKILLs our process. The helper connection dies (`read frame header: failed to fill whole buffer`).

This is exactly the bug bundle in #152: helper dies ~5s after install rejection, on FW 10.40, with `err_code=0x80b2116f`.

**Fix:** Lower the threshold from `fw_major >= 11` to `fw_major >= 10` so FW 10.xx uses `PS5_SYSTEM_INSTALL_AUTHID`, matching the DPI daemon's proven behavior on the same firmware.

## Issue #208 — Outdated reconnect description

Updated `connection_description` in `en.ts` to reflect that the helper auto-reconnects after rest mode / network drops (new in 4.1.0).

## Diagnostics

Also refreshed the `0x80B2116F` user-facing message (`err_install_116f_game`) and the engine-side `err_code_message` comment to note the FW 10+ authid-mismatch cause, so future bug bundles point at the right tier.

## Testing

- `cargo test -p ps5upload-core --lib`: 163 passed
- `npm --prefix client run typecheck`: clean
- `npm --prefix client run lint`: clean
- `npm --prefix client test`: 782 passed

Payload C change is a single-character threshold (`11` → `10`) plus a comment refresh; builds against the PS5 SDK in CI (no local SDK).