### PR TITLE
fix: Linux segfault on Screenshots + Remote Play error masking

### DIFF
--- a/client/src-tauri/Cargo.lock
+++ b/client/src-tauri/Cargo.lock
@@ -3330,7 +3330,7 @@ name = "ps5upload-core"
 version = "4.1.2"
 dependencies = [
  "anyhow",
- "base64 0.22.1",
+ "base64 0.23.0",
  "blake3",
  "ftx2-proto",
  "image",
@@ -3381,7 +3381,7 @@ version = "4.1.2"
 dependencies = [
  "anyhow",
  "axum",
- "base64 0.22.1",
+ "base64 0.23.0",
  "ftx2-proto",
  "ps5upload-core",
  "ps5upload-pkg",

--- a/client/src-tauri/src/commands/screenshot_convert.rs
+++ b/client/src-tauri/src/commands/screenshot_convert.rs
@@ -91,6 +91,30 @@ mod desktop {
 
     /// Decode a JPEG XR byte buffer and return PNG-encoded bytes (RGB8).
     pub fn convert_jxr_to_png(jxr: &[u8]) -> Result<Vec<u8>, String> {
+        // Validate the JPEG XR file signature before handing the buffer to
+        // the C codec (jxrlib). A truncated or corrupted .jxr — common for
+        // PS5 thumbnail variants that are still being written, or a
+        // download that was cut short — can cause the native `copy_all` to
+        // read past the buffer and SIGSEGV, taking the whole app down.
+        // Rejecting non-JXR bytes here turns a hard crash into a clean
+        // error the UI can surface. The signature is the 4-byte TIFF-style
+        // marker: `II\xBC\x01` (little-endian) or `MM\xBC\x01` (big-endian).
+        if jxr.len() < 8 {
+            return Err(format!(
+                "jxr too small ({} bytes) — likely a truncated download",
+                jxr.len()
+            ));
+        }
+        let is_jxr = (jxr[0] == 0x49 && jxr[1] == 0x49 && jxr[2] == 0xBC && jxr[3] == 0x01)
+            || (jxr[0] == 0x4D && jxr[1] == 0x4D && jxr[2] == 0xBC && jxr[3] == 0x01);
+        if !is_jxr {
+            return Err(format!(
+                "not a JPEG XR file (magic: {:02x?}) — the first 4 bytes \
+                 don't match the JXR signature. This may be a regular JPEG \
+                 or PNG mislabeled .jxr.",
+                &jxr[..4]
+            ));
+        }
         let (width, height, rgb8) = decode_to_rgb8(jxr)?;
         let mut out = Vec::new();
         image::codecs::png::PngEncoder::new(Cursor::new(&mut out))

--- a/client/src/api/ps5.ts
+++ b/client/src/api/ps5.ts
@@ -3762,6 +3762,10 @@ export interface RemotePlayStatus {
   pin: string;
   account_id: string;
   seconds_left: number;
+  /** Diagnostic from the payload when state is "failed" or "timeout"
+   *  (e.g. "sceRemoteplayInitialize failed: 0x8094xxxx"). Empty when the
+   *  request succeeded. */
+  err?: string;
 }
 
 export async function remoteplayRequest(

--- a/client/src/screens/RemotePlay/index.tsx
+++ b/client/src/screens/RemotePlay/index.tsx
@@ -261,6 +261,13 @@ export default function RemotePlayScreen() {
                 {status.seconds_left > 0 ? status.seconds_left : "—"}
               </dd>
             </dl>
+            {status.err && (
+              <div className="mt-3 rounded-md border border-[var(--color-error)] bg-[var(--color-error-bg,transparent)] p-3">
+                <p className="text-xs text-[var(--color-error)]">
+                  {status.err}
+                </p>
+              </div>
+            )}
           </div>
         )}
       </ConnectionGate>

--- a/engine/crates/ps5upload-core/src/remoteplay.rs
+++ b/engine/crates/ps5upload-core/src/remoteplay.rs
@@ -16,6 +16,12 @@ pub struct RemotePlayStatus {
     pub account_id: String,
     #[serde(default)]
     pub seconds_left: i32,
+    /// Diagnostic the payload writes when entering a FAILED/TIMEOUT state
+    /// (e.g. "sceRemoteplayInitialize failed: 0x8094xxxx"). Surfaced to the
+    /// UI so the user sees *why* the PIN couldn't be generated, not just
+    /// the bare word "failed".
+    #[serde(default)]
+    pub err: String,
 }
 
 pub fn remoteplay_request(addr: &str, manual_account_id: Option<&str>) -> Result<()> {
@@ -29,6 +35,22 @@ pub fn remoteplay_request(addr: &str, manual_account_id: Option<&str>) -> Result
             "payload rejected REMOTEPLAY_REQUEST: {}",
             String::from_utf8_lossy(&resp)
         );
+    }
+    // The payload acks with frame type RemotePlayStatus (189) and body
+    // {"ok":true|false}. A non-Error frame was previously treated as success
+    // without inspecting the body — so a genuine on-console failure
+    // (libSceRemoteplay absent, Initialize returned non-zero, no foreground
+    // user, …) was silently swallowed and the user only saw "failed" on the
+    // next status poll. Parse the ack and bail when the payload says !ok.
+    #[derive(Deserialize)]
+    struct RequestAck {
+        #[serde(default)]
+        ok: bool,
+    }
+    let ack: RequestAck = serde_json::from_slice(&resp)
+        .map_err(|e| anyhow::anyhow!("bad REMOTEPLAY_REQUEST ack: {e}"))?;
+    if !ack.ok {
+        bail!("payload reports the Remote Play request failed on-console");
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

Fixes two bugs from #229 on Debian 13 / FW 11.60.

### Bug 1 — Segfault when accessing the Screenshots tab

**Symptom:** Clicking the Screenshots tab causes a segmentation fault, crashing the app.

**Root cause:** The JPEG XR C codec ( via the  crate) can SIGSEGV on truncated or corrupted  files. When the Screenshots tab opens, it automatically decodes a thumbnail  for every visible row — so even one bad thumbnail crashes the entire app.

**Fix:** Validate the JPEG XR file signature ( or ) and minimum size (8 bytes) **before** handing the buffer to the C codec. A malformed file now returns a clean Rust error ( / ) instead of a native SIGSEGV.

### Bug 2 — Remote Play 'Generate PIN' shows 'state=failed' with no explanation

**Symptom:** Pressing 'Generate PIN' results in  with no diagnostic.

**Root cause (two compounding defects):**
1. **Engine masks the failure:**  treated any non- frame as success without inspecting the  body — so a genuine on-console failure (libSceRemoteplay absent, Initialize returned non-zero, no foreground user) was silently swallowed.
2. **Diagnostic invisible:** The payload writes a detailed  string (e.g. ) into the status JSON, but neither the engine's  struct nor the client's TS interface declared an  field — serde silently discarded the only clue.

**Fix:**
- **engine/remoteplay.rs:** Parse the request ack body and  when 
- **engine/remoteplay.rs:** Add  field to  struct
- **client/api/ps5.ts:** Add  to the TS  interface
- **client/screens/RemotePlay:** Display the  diagnostic in a bordered error box below the status grid when present

The most common root cause is  being unavailable on the user's firmware, or Remote Play being disabled in PS5 settings. The user will now see the exact Sony error code.

## Test Plan

- [x]  — 163 tests pass
- [x]  (src-tauri) — 83 tests pass
- [x]  — clean (engine + desktop)
- [x]  — clean
- [x]  — clean
- [x]  — 783 tests pass
- [ ] HW test: verify Screenshots tab no longer crashes
- [ ] HW test: verify Remote Play error diagnostic is visible