### PR TITLE
fix: ship NSIS installer with WebView2 bootstrapper for Windows 10

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -315,7 +315,12 @@ jobs:
           LINUXDEPLOY_VERBOSE: "1"
         run: |
           if [ "$PLATFORM" = "windows" ]; then
+            # Build the raw exe (--no-bundle) AND the NSIS installer. The
+            # NSIS installer bundles the WebView2 bootstrapper, which is
+            # essential on Windows 10 where WebView2 is not pre-installed
+            # (issue #221: app shows in Task Manager but no window appears).
             npx tauri build --target "$RUST_TARGET" --ci --no-bundle
+            npx tauri build --target "$RUST_TARGET" --ci --bundles nsis
           else
             npx tauri build --target "$RUST_TARGET" --ci --verbose
           fi
@@ -378,6 +383,14 @@ jobs:
               PS5UP_ZIP="$dist_abs/PS5Upload.zip" \
                 pwsh -NoProfile -Command 'Compress-Archive -LiteralPath $env:PS5UP_EXE -DestinationPath $env:PS5UP_ZIP -CompressionLevel Optimal'
               rm -rf "$staging"
+              # Also ship the NSIS installer (includes WebView2 bootstrapper
+              # for Windows 10 users who don't have Edge/WebView2 installed).
+              nsis_setup="$(find "$bundle" -type f -name "*-setup.exe" 2>/dev/null | head -n1)"
+              if [ -n "$nsis_setup" ] && [ -f "$nsis_setup" ]; then
+                cp -v "$nsis_setup" "$dist_abs/PS5Upload-setup.exe"
+              else
+                echo "::warning::NSIS installer not found (WebView2 bootstrapper not bundled)"
+              fi
               ;;
           esac
           # Ship the engine sidecar binary standalone too (it's also bundled
@@ -584,6 +597,11 @@ jobs:
           for f in artifacts/ps5upload-windows-*/PS5Upload.zip; do
             arch="$(basename "$(dirname "$f")" | sed 's/^ps5upload-windows-//')"
             cp -v "$f" "release/PS5Upload-${TAG_VERSION}-win-${arch}.zip"
+          done
+          # NSIS installer (includes WebView2 bootstrapper for Win10 users).
+          for f in artifacts/ps5upload-windows-*/PS5Upload-setup.exe; do
+            arch="$(basename "$(dirname "$f")" | sed 's/^ps5upload-windows-//')"
+            cp -v "$f" "release/PS5Upload-${TAG_VERSION}-win-${arch}-setup.exe"
           done
           for f in artifacts/ps5upload-linux-*/PS5Upload.zip; do
             arch="$(basename "$(dirname "$f")" | sed 's/^ps5upload-linux-//')"

--- a/client/src-tauri/tauri.conf.json
+++ b/client/src-tauri/tauri.conf.json
@@ -81,6 +81,15 @@
           "height": 400
         }
       }
+    },
+    "windows": {
+      "nsis": {
+        "installMode": "currentUser",
+        "displayLanguageSelector": false
+      },
+      "webviewInstallMode": {
+        "type": "downloadBootstrapper"
+      }
     }
   }
 }


### PR DESCRIPTION
## Fixes #221

On Windows 10 machines without WebView2 runtime installed, the app shows in Task Manager but no window appears.

## Root Cause
The publish workflow only builds a raw exe (`--no-bundle`) for Windows, shipped in a zip. This exe has no way to bootstrap the WebView2 runtime. Windows 10 does not bundle WebView2 (unlike Windows 11).

## Fix
Build an **NSIS installer** (`--bundles nsis`) alongside the raw exe. The NSIS installer is configured with `webviewInstallMode: downloadBootstrapper`, which automatically downloads and installs the WebView2 runtime on first launch if it's missing.

## Changes
- **`client/src-tauri/tauri.conf.json`**: Added `bundle.windows.nsis` (`installMode: currentUser`) and `bundle.windows.webviewInstallMode` (`type: downloadBootstrapper`).
- **`.github/workflows/publish.yml`**:
  - Build NSIS installer alongside `--no-bundle` exe
  - Collect `PS5Upload-setup.exe` from bundle output
  - Upload as `PS5Upload-<ver>-win-<arch>-setup.exe` release asset

## Notes
- The raw exe zip is still shipped for users who already have WebView2 installed.
- `downloadBootstrapper` is actually Tauri's default mode — making it explicit for clarity.
- Validated config with `cargo check` — compiles cleanly.