### PR TITLE
fix: transparent ps5 info background

### DIFF
--- a/client/src/screens/More/index.tsx
+++ b/client/src/screens/More/index.tsx
@@ -78,8 +78,10 @@ export default function MoreScreen() {
 
       {/* Sticky zone: console switcher + search. Sticks inside <main>'s
           scroll context — this screen adds no scroller of its own. */}
-      <div className="sticky top-0 z-10 -mx-4 bg-[var(--color-bg)] px-4 pb-3 pt-1">
-        <RosterPicker />
+      <div className="sticky top-0 z-10 -mx-4 bg-[var(--color-bg)] px-4 pb-0 pt-1 backdrop-blur-[3px]">
+        <div className="bg-[var(--color-surface)]">
+          <RosterPicker />
+        </div>
         <div className="mt-3">
           <Input
             type="search"

--- a/client/src/screens/More/index.tsx
+++ b/client/src/screens/More/index.tsx
@@ -79,7 +79,7 @@ export default function MoreScreen() {
       {/* Sticky zone: console switcher + search. Sticks inside <main>'s
           scroll context — this screen adds no scroller of its own. */}
       <div className="sticky top-0 z-10 -mx-4 px-4 pb-0 pt-1">
-        <div className="absolute inset-0 -z-10 bg-[var(--color-bg)]/80 backdrop-blur-[3px]" />
+        <div className="absolute inset-0 -z-10 backdrop-blur-[3px]" />
         <div className="bg-[var(--color-surface)]">
           <RosterPicker />
         </div>

--- a/client/src/screens/More/index.tsx
+++ b/client/src/screens/More/index.tsx
@@ -78,7 +78,8 @@ export default function MoreScreen() {
 
       {/* Sticky zone: console switcher + search. Sticks inside <main>'s
           scroll context — this screen adds no scroller of its own. */}
-      <div className="sticky top-0 z-10 -mx-4 bg-[var(--color-bg)] px-4 pb-0 pt-1 backdrop-blur-[3px]">
+      <div className="sticky top-0 z-10 -mx-4 px-4 pb-0 pt-1">
+        <div className="absolute inset-0 -z-10 bg-[var(--color-bg)]/80 backdrop-blur-[3px]" />
         <div className="bg-[var(--color-surface)]">
           <RosterPicker />
         </div>

--- a/client/src/screens/More/index.tsx
+++ b/client/src/screens/More/index.tsx
@@ -78,8 +78,8 @@ export default function MoreScreen() {
 
       {/* Sticky zone: console switcher + search. Sticks inside <main>'s
           scroll context — this screen adds no scroller of its own. */}
-      <div className="sticky top-0 z-10 -mx-4 px-4 pb-0 pt-1">
-        <div className="absolute inset-0 -z-10 backdrop-blur-[3px]" />
+      <div className="sticky top-0 z-10 -mx-4 px-4 pb-0 pt-0">
+        <div className="absolute inset-0 -z-10" />
         <div className="bg-[var(--color-surface)]">
           <RosterPicker />
         </div>


### PR DESCRIPTION
As in changes

# Pull Request

## Description
before
<img width="860" height="171" alt="image" src="https://github.com/user-attachments/assets/9664a471-78dd-4ad8-baf1-b69a88e21ede" />
after
<img width="871" height="168" alt="image" src="https://github.com/user-attachments/assets/c5943cce-91ba-4f8e-8dff-e12fd835953b" />



## Type of Change
<!-- Mark relevant options with an [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
<!-- List the specific changes -->

- Made the whole background div shorter
- Added an opaque background to the RosterPicker
- Set the top padding of RosterPicker to 0

