### PR TITLE
fix(engine): resync Cargo.lock with the tower-http 0.7 bump

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -1725,13 +1725,14 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.11"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+checksum = "08a05a66a4fdd61cbbe0a1d755ffe0ca6aba159dd4820936a0ff8a8278245b9c"
 dependencies = [
  "bitflags",
  "bytes",
  "http",
+ "percent-encoding",
  "pin-project-lite",
  "tower-layer",
  "tower-service",


### PR DESCRIPTION
Main is currently broken for `cargo check --locked`.

#279 raised `tower-http` to `"0.7"` in `engine/Cargo.toml`, but that PR and #292
both touched `engine/Cargo.lock`. Squash-merging them left the lock still
pinning `0.6.11`, so the manifest and lock disagree:

```
error: cannot update the lock file .../engine/Cargo.lock because --locked was passed
```

Each PR was green on its own — only the merged combination is inconsistent,
which is why nothing caught it pre-merge.

Regenerated the lock: `tower-http` 0.6.11 → 0.7.1, plus its new
`percent-encoding` dependency. The `sevenz-rust2` 0.22.2 / `lzma-rust2` 0.20.1
pins from #292 survived the merges correctly and are unchanged here.

## Verification

- `cargo check --locked` clean — engine workspace **and** `client/src-tauri`
- `npm ci` clean
- `make test` green
- `cargo fmt --all --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HuFsdD3iU8U5m6PKuqawv7