### PR TITLE
fix(webui): close the browser/engine parity gap behind the #295 report

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,7 +17,9 @@ engine/target/
 client/dist/
 client/src-tauri/target/
 client/src-tauri/gen/
-payload/ps5upload.elf
+# NOT excluded: payload/*.elf. The engine embeds these at build time
+# (engine/crates/ps5upload-engine/build.rs); excluding them here silently
+# produced images that could install base games but not updates (#295).
 payload/ps5upload.elf.gz
 
 # Node (installed fresh in the frontend stage)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,41 @@ What's new in ps5upload, written for humans.
   people hunting for the wrong version of a game. Failing to start the
   installer now says exactly that, and what to do about it.
 
+- **Most of the app now works from the self-hosted web UI.** The browser build
+  translates each of the desktop app's actions into an engine request, and that
+  translation table had fallen a long way behind: Cheats, the SMB browser,
+  Backup, SDK Changer, Game Activity, Notifications, the FTP server, Fan Curve,
+  FW Spoof, drive sensors, avatar apply, TMDB lookups, package and archive
+  inspection (zip / 7z / rar / ffpkg / bps), user create and delete, and every
+  transfer and download action were all missing from it. The engine had been
+  serving every one of those routes the whole time, so the screens rendered
+  normally in a browser and then failed the moment you pressed a button. All of
+  them now go through. A build-time check keeps the two sides in step, so a
+  newly added action can no longer go missing here unnoticed.
+
+- **Connection status works in the browser.** Steps 1 and 2 of the Connect
+  screen could not tell whether your PS5 was reachable, because probing a TCP
+  port is something a browser cannot do. The engine now probes on its behalf —
+  and it is the better vantage point anyway, since it sits on the same network
+  as the console.
+
+- **No more "Save failed" alert on a successful install.** Every change to the
+  upload queue tried to write the desktop app's queue file, which does not
+  exist in a browser. The Upload screen reported that as "Queue changes could
+  not be saved — free disk space or fix permissions" over installs that had in
+  fact succeeded. The queue is now kept in the browser itself, and survives a
+  reload.
+
+- **Docker images built from source carry the on-console installer.** The two
+  helper images the engine embeds were never copied into the build context, so
+  anyone building their own image got one that installed base games but turned
+  every update away — the same failure this release fixes everywhere else. Only
+  the official images were unaffected.
+
+- **Screens that cannot work in a browser are no longer offered there.** The
+  first-run wizard and the SMB "download to this computer" button both need the
+  desktop app; they now stay hidden instead of failing when used.
+
 ---
 
 ## 5.15.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,36 +4,9 @@ What's new in ps5upload, written for humans.
 
 ---
 
-## 5.16.0
+## 5.17.0
 
-**Game updates and DLC install from the self-hosted web UI.**
-
-- **Updates and add-ons now install from the browser, not just base games.**
-  An update can't go through the PS5's in-app installer — on firmware 10 and
-  newer it turns patches away, and the one remaining in-app route is the
-  destructive one that can wipe the base game, so ps5upload refuses it. The
-  install that actually works hands the package to a separate on-console
-  installer daemon, which means sending that daemon to the console and putting
-  the ps5upload helper back afterwards. The desktop app does that from its own
-  bundled copies. A browser tab can't: it has no way to open a socket to the
-  console, and no copy of the files. So every update installed from the web UI
-  stopped with "this update couldn't be applied", while base games — which
-  never need that route — installed fine. The engine now carries both helper
-  images and does this itself, so the browser and the desktop app take the same
-  install path. This also unblocks Stream (beta) installs in the browser.
-
-  The released engine binaries and the official Docker images
-  (`ghcr.io/phantomptr/ps5upload-engine`, `…-engine-webui`) include the images.
-  If you build the engine from source without the PS5 payload SDK it has none,
-  and it now says so plainly instead of reporting the console as having
-  declined the update; you can point it at your own copies with
-  `PS5UPLOAD_PAYLOAD_DIR`.
-
-- **A clearer message when the update never reached the console.** "The PS5
-  declined it — most often because the update doesn't match your installed
-  version" was shown even when the request never got that far, which sent
-  people hunting for the wrong version of a game. Failing to start the
-  installer now says exactly that, and what to do about it.
+**The self-hosted web UI catches up with the desktop app.**
 
 - **Most of the app now works from the self-hosted web UI.** The browser build
   translates each of the desktop app's actions into an engine request, and that
@@ -69,6 +42,39 @@ What's new in ps5upload, written for humans.
 - **Screens that cannot work in a browser are no longer offered there.** The
   first-run wizard and the SMB "download to this computer" button both need the
   desktop app; they now stay hidden instead of failing when used.
+
+---
+
+## 5.16.0
+
+**Game updates and DLC install from the self-hosted web UI.**
+
+- **Updates and add-ons now install from the browser, not just base games.**
+  An update can't go through the PS5's in-app installer — on firmware 10 and
+  newer it turns patches away, and the one remaining in-app route is the
+  destructive one that can wipe the base game, so ps5upload refuses it. The
+  install that actually works hands the package to a separate on-console
+  installer daemon, which means sending that daemon to the console and putting
+  the ps5upload helper back afterwards. The desktop app does that from its own
+  bundled copies. A browser tab can't: it has no way to open a socket to the
+  console, and no copy of the files. So every update installed from the web UI
+  stopped with "this update couldn't be applied", while base games — which
+  never need that route — installed fine. The engine now carries both helper
+  images and does this itself, so the browser and the desktop app take the same
+  install path. This also unblocks Stream (beta) installs in the browser.
+
+  The released engine binaries and the official Docker images
+  (`ghcr.io/phantomptr/ps5upload-engine`, `…-engine-webui`) include the images.
+  If you build the engine from source without the PS5 payload SDK it has none,
+  and it now says so plainly instead of reporting the console as having
+  declined the update; you can point it at your own copies with
+  `PS5UPLOAD_PAYLOAD_DIR`.
+
+- **A clearer message when the update never reached the console.** "The PS5
+  declined it — most often because the update doesn't match your installed
+  version" was shown even when the request never got that far, which sent
+  people hunting for the wrong version of a game. Failing to start the
+  installer now says exactly that, and what to do about it.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -529,11 +529,14 @@ port 9021 — a third-party component, not part of ps5upload.
   on-console install daemon, and the engine has to send it to the console
   and put the ps5upload helper back afterwards — the desktop app does this
   from its own copies, which a browser tab cannot reach. The released
-  engine binaries and the official Docker images include them. A source
-  build only has them if you ran `make payload` first (it needs the PS5
-  payload SDK); otherwise point the engine at a directory holding
-  `ps5upload.elf` and `ezremote-dpi.elf` with
-  `-e PS5UPLOAD_PAYLOAD_DIR=/path/to/elves`. Base games install either way.
+  engine binaries and the official Docker images include them, and a
+  Docker image you build yourself does too — `ezremote-dpi.elf` is in the
+  repository, and that is the one the update install needs. A plain
+  `cargo build` picks it up only if you build from a full checkout; the
+  ps5upload helper itself is built by `make payload` (it needs the PS5
+  payload SDK). Either way you can point the engine at your own copies
+  with `-e PS5UPLOAD_PAYLOAD_DIR=/path/to/elves`. Base games install
+  regardless.
 
 ## Contributing
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -351,12 +351,20 @@ export default function App() {
         <Route path="/nanodns" element={<Navigate to="/payloads?tab=nanodns" replace />} />
         <Route path="/nano-dns" element={<Navigate to="/payloads?tab=nanodns" replace />} />
         <Route path="/shadowmount" element={<Navigate to="/payloads?tab=shadowmount" replace />} />
+        {/* The wizard's whole point is step 2: download the payload ELFs to
+            this machine and send them to the console over a raw socket.
+            Neither is possible from a browser, and the /payloads entry it
+            builds on is already hideInBrowser — so guard it the same way
+            rather than stranding self-hosted users on a wizard that dies
+            at step 2. */}
         <Route
           path="/first-run"
           element={
-            <Suspense fallback={<ScreenLoader />}>
-              <FirstRunScreen />
-            </Suspense>
+            <NativeOnlyRoute>
+              <Suspense fallback={<ScreenLoader />}>
+                <FirstRunScreen />
+              </Suspense>
+            </NativeOnlyRoute>
           }
         />
         <Route

--- a/client/src/api/ps5.ts
+++ b/client/src/api/ps5.ts
@@ -8,6 +8,7 @@ import { Channel } from "@tauri-apps/api/core";
 import { getEngineUrl } from "../state/engine";
 // Logging wrapper: every command leaves a trace breadcrumb + logs failures at
 // warn. See lib/invokeLogged.ts. (Channel still comes straight from core.)
+import { isTauriEnv } from "../lib/tauriEnv";
 import { invoke } from "../lib/invokeLogged";
 import { randomHexId } from "../lib/randomId";
 import { getCachedIcon, setCachedIcon } from "../lib/iconMemoryCache";
@@ -781,17 +782,59 @@ export async function dirDiffPreview(
   });
 }
 
+/** Where the browser keeps the upload queue. The desktop app writes a
+ *  real file via persistence.rs; a browser has no such thing, and the
+ *  engine's copy would be shared by every browser pointed at it — so
+ *  this is deliberately per-browser, like the rest of the web UI's
+ *  settings. */
+const UPLOAD_QUEUE_KEY = "ps5upload.uploadQueue";
+
 /** Whole-document load for the upload-queue store. The renderer owns
  *  the shape — see state/uploadQueue.ts. Returns `{}` for first-time
  *  use (Tauri returns the empty default from persistence.rs). */
 export async function uploadQueueLoad<T = unknown>(): Promise<T> {
+  if (!isTauriEnv()) {
+    try {
+      const raw = localStorage.getItem(UPLOAD_QUEUE_KEY);
+      return (raw ? JSON.parse(raw) : {}) as T;
+    } catch {
+      // Private windows and blocked site-data both throw here. An
+      // unreadable queue is an empty queue, not a broken app.
+      return {} as T;
+    }
+  }
   return invoke<T>("upload_queue_load");
 }
 
 /** Whole-document save for the upload-queue store. Caller is
  *  responsible for serializing concurrent saves; the Tauri side has a
- *  per-store mutex so worst case is ordering, not corruption. */
+ *  per-store mutex so worst case is ordering, not corruption.
+ *
+ *  In the browser this used to throw BrowserUnsupportedError on every
+ *  queue mutation, which the Upload screen surfaced as a red "Save
+ *  failed — free disk space or fix permissions" banner on an install
+ *  that had in fact succeeded (#295). */
 export async function uploadQueueSave(doc: unknown): Promise<void> {
+  if (!isTauriEnv()) {
+    try {
+      localStorage.setItem(UPLOAD_QUEUE_KEY, JSON.stringify(doc));
+    } catch (e) {
+      // Quota exhaustion is the one case worth reporting: it means the
+      // queue silently stopped persisting. Everything else (private
+      // window, blocked storage) is a no-op by design.
+      const wrapped = new Error(
+        `couldn't save the upload queue in this browser: ${
+          e instanceof Error ? e.message : String(e)
+        }`,
+      );
+      // Keep the original around for the log bundle (eslint's
+      // preserve-caught-error rule enforces this); the target is ES2020,
+      // so `cause` is assigned rather than passed to the constructor.
+      (wrapped as Error & { cause?: unknown }).cause = e;
+      throw wrapped;
+    }
+    return;
+  }
   await invoke("upload_queue_save", { doc });
 }
 

--- a/client/src/api/uploadQueuePersistence.test.ts
+++ b/client/src/api/uploadQueuePersistence.test.ts
@@ -1,0 +1,72 @@
+/**
+ * The upload queue's browser persistence.
+ *
+ * In a self-hosted browser session every queue mutation used to call the
+ * Tauri-only `upload_queue_save`, which threw BrowserUnsupportedError.
+ * The Upload screen caught it and rendered "Save failed — free disk space
+ * or fix permissions" over an install that had actually succeeded, which
+ * is how it showed up in the #295 hardware run.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../lib/tauriEnv", () => ({ isTauriEnv: () => false }));
+vi.mock("../lib/invokeLogged", () => ({
+  invoke: vi.fn(async () => {
+    throw new Error("the browser must never reach the Tauri command");
+  }),
+}));
+
+import { uploadQueueLoad, uploadQueueSave } from "./ps5";
+import { invoke } from "../lib/invokeLogged";
+
+/** Minimal in-memory localStorage — vitest runs these files in node, so
+ *  there is no DOM. Mirrors the stub in state/uploadQueue.test.ts. */
+function stubStorage() {
+  const map = new Map<string, string>();
+  const store = {
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => void map.set(k, v),
+    removeItem: (k: string) => void map.delete(k),
+    clear: () => map.clear(),
+  };
+  vi.stubGlobal("localStorage", store);
+  return store;
+}
+
+describe("upload queue persistence in the browser", () => {
+  let store: ReturnType<typeof stubStorage>;
+
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    store = stubStorage();
+    vi.clearAllMocks();
+  });
+
+  it("round-trips the queue document without touching Tauri", async () => {
+    await uploadQueueSave({ items: [{ id: "a" }] });
+    expect(invoke).not.toHaveBeenCalled();
+    await expect(uploadQueueLoad()).resolves.toEqual({ items: [{ id: "a" }] });
+  });
+
+  it("reads an empty document on first use", async () => {
+    await expect(uploadQueueLoad()).resolves.toEqual({});
+  });
+
+  it("treats unreadable storage as an empty queue, not an error", async () => {
+    // Private windows and blocked site-data throw on access. The queue
+    // being unavailable must not take the Upload screen down with it.
+    store.getItem = () => {
+      throw new Error("SecurityError");
+    };
+    await expect(uploadQueueLoad()).resolves.toEqual({});
+  });
+
+  it("reports a failed write so a full quota is not silent", async () => {
+    store.setItem = () => {
+      throw new Error("QuotaExceededError");
+    };
+    await expect(uploadQueueSave({ items: [] })).rejects.toThrow(
+      /couldn't save the upload queue/,
+    );
+  });
+});

--- a/client/src/lib/browserInvoke.test.ts
+++ b/client/src/lib/browserInvoke.test.ts
@@ -1,6 +1,6 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { browserInvoke, BrowserUnsupportedError, timeSyncBody } from "./browserInvoke";
+import { browserInvoke, BrowserUnsupportedError, parseSseBlock, timeSyncBody } from "./browserInvoke";
 
 vi.mock("../state/engine", () => ({
   getEngineUrl: () => "http://engine.test:19113",
@@ -130,5 +130,220 @@ describe("loader-port commands the DPI fallback depends on", () => {
     await expect(browserInvoke("payload_bundled_path", {})).rejects.toBeInstanceOf(
       BrowserUnsupportedError,
     );
+  });
+});
+
+describe("engine-backed commands the web UI depends on (#295 follow-up)", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function captureFetch(body: unknown) {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init: RequestInit) => {
+        calls.push({ url, init });
+        return { ok: true, status: 200, json: async () => body } as unknown as Response;
+      }),
+    );
+    return calls;
+  }
+
+  const B = "http://engine.test:19113";
+
+  it("builds cheats_get with both query params, engine-encoded", async () => {
+    const calls = captureFetch({ cheats: [] });
+    await browserInvoke("cheats_get", {
+      req: { addr: "192.168.1.50:9113", title_id: "CUSA03474" },
+    });
+    expect(calls[0].url).toBe(
+      `${B}/api/ps5/cheats/get?addr=192.168.1.50%3A9113&title_id=CUSA03474`,
+    );
+  });
+
+  it("omits addr entirely when the caller passes null", async () => {
+    // The Rust side pushes no param at all for None. A literal `addr=null`
+    // would be parsed as a hostname and fail the connect.
+    const calls = captureFetch({ cheats: [] });
+    await browserInvoke("cheats_list", { req: { addr: null } });
+    expect(calls[0].url).toBe(`${B}/api/ps5/cheats/list`);
+  });
+
+  it("keeps since_seq=0 rather than dropping it as falsy", async () => {
+    // Dropping it would make the engine replay the whole notification
+    // backlog on every poll instead of returning only new rows.
+    const calls = captureFetch({ notifications: [] });
+    await browserInvoke("notif_list", { req: { addr: null, since_seq: 0 } });
+    expect(calls[0].url).toBe(`${B}/api/ps5/notif/list?since_seq=0`);
+  });
+
+  it("sends refresh only when it is actually set", async () => {
+    // The engine parses `refresh` as a string, so `refresh=false` reads
+    // as truthy and would force a cache-busting refetch every time.
+    const calls = captureFetch({});
+    await browserInvoke("tmdb_fetch", {
+      req: { addr: null, title_id: "CUSA03474", refresh: false, region: null },
+    });
+    expect(calls[0].url).toBe(`${B}/api/ps5/tmdb/fetch?title_id=CUSA03474`);
+
+    await browserInvoke("tmdb_fetch", {
+      req: { addr: null, title_id: "CUSA03474", refresh: true, region: null },
+    });
+    expect(calls[1].url).toBe(
+      `${B}/api/ps5/tmdb/fetch?title_id=CUSA03474&refresh=true`,
+    );
+  });
+
+  it("drops an empty backup tag the way the Rust command does", async () => {
+    const calls = captureFetch({ snapshots: [] });
+    await browserInvoke("backup_list", { req: { addr: null, tag: "" } });
+    expect(calls[0].url).toBe(`${B}/api/ps5/backup/list`);
+  });
+
+  it("passes transfer_zip's body through in snake_case", async () => {
+    // A key lost in translation here does not throw — it silently changes
+    // where a multi-GB install lands, or removes its bandwidth cap.
+    const calls = captureFetch({ job_id: "j1" });
+    await browserInvoke("transfer_zip", {
+      req: {
+        zip_path: "/srv/games/x.zip",
+        dest_root: "/mnt/usb0",
+        addr: "192.168.1.50:9113",
+        tx_id: "tx1",
+        excludes: ["a"],
+        bandwidth_cap_mbps: 200,
+      },
+    });
+    expect(calls[0].url).toBe(`${B}/api/transfer/zip`);
+    expect(JSON.parse(calls[0].init.body as string)).toEqual({
+      zip_path: "/srv/games/x.zip",
+      dest_root: "/mnt/usb0",
+      addr: "192.168.1.50:9113",
+      tx_id: "tx1",
+      excludes: ["a"],
+      bandwidth_cap_mbps: 200,
+    });
+  });
+
+  it("maps ffpkg_extract's camelCase args onto the engine's snake_case body", async () => {
+    const calls = captureFetch({ ok: true });
+    await browserInvoke("ffpkg_extract", {
+      ffpkgPath: "/srv/a.ffpkg",
+      innerPath: "eboot.bin",
+      destDir: "/tmp/out",
+    });
+    expect(JSON.parse(calls[0].init.body as string)).toEqual({
+      ffpkg_path: "/srv/a.ffpkg",
+      inner_path: "eboot.bin",
+      dest_dir: "/tmp/out",
+    });
+  });
+
+  it("still refuses commands that write to a host path", async () => {
+    // smb_download_file saves bytes to the desktop's disk; mapping it
+    // would silently write onto the ENGINE's filesystem instead.
+    await expect(
+      browserInvoke("smb_download_file", { req: {} }),
+    ).rejects.toBeInstanceOf(BrowserUnsupportedError);
+  });
+});
+
+describe("streaming archive inspect over SSE", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  /** Serve a fixed SSE body as a ReadableStream, split across chunks so the
+   *  parser's cross-chunk buffering is actually exercised. */
+  function stubSse(chunks: string[], ok = true) {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok,
+        status: ok ? 200 : 500,
+        json: async () => ({ error: "bad request" }),
+        text: async () => "bad request",
+        body: {
+          getReader() {
+            let i = 0;
+            return {
+              read: async () =>
+                i < chunks.length
+                  ? { done: false, value: new TextEncoder().encode(chunks[i++]) }
+                  : { done: true, value: undefined },
+              cancel: async () => {},
+            };
+          },
+        },
+      })) as unknown as typeof fetch,
+    );
+  }
+
+  it("forwards progress ticks and resolves with the done payload", async () => {
+    stubSse([
+      'event: progress\ndata: {"entries_seen":10}\n\nevent: prog',
+      'ress\ndata: {"entries_seen":25}\n\n',
+      'event: done\ndata: {"entries":25,"total_bytes":99}\n\n',
+    ]);
+    const seen: unknown[] = [];
+    const res = await browserInvoke("zip_inspect_stream", {
+      req: { zip_path: "/srv/a.zip" },
+      onProgress: { onmessage: (p: unknown) => seen.push(p) },
+    });
+    // The second event was split mid-word across two chunks; if the
+    // buffer were per-chunk it would be lost.
+    expect(seen).toEqual([{ entries_seen: 10 }, { entries_seen: 25 }]);
+    expect(res).toEqual({ entries: 25, total_bytes: 99 });
+  });
+
+  it("surfaces an SSE error event as a rejection", async () => {
+    stubSse(['event: error\ndata: {"error":"unreadable archive"}\n\n']);
+    await expect(
+      browserInvoke("sevenz_inspect_stream", {
+        req: { archive_path: "/srv/a.7z" },
+        onProgress: { onmessage: () => {} },
+      }),
+    ).rejects.toThrow(/unreadable archive/);
+  });
+
+  it("fails loudly if the stream ends without done or error", async () => {
+    stubSse(['event: progress\ndata: {"entries_seen":1}\n\n']);
+    await expect(
+      browserInvoke("zip_inspect_stream", {
+        req: { zip_path: "/srv/a.zip" },
+        onProgress: { onmessage: () => {} },
+      }),
+    ).rejects.toThrow(/closed the inspect stream/);
+  });
+
+  it("keeps going when the progress callback throws", async () => {
+    // Matches the Rust Channel::send, which is fire-and-forget: an
+    // unmounted component must not abort a succeeding inspect.
+    stubSse([
+      'event: progress\ndata: {"entries_seen":1}\n\n',
+      'event: done\ndata: {"entries":1}\n\n',
+    ]);
+    const res = await browserInvoke("zip_inspect_stream", {
+      req: { zip_path: "/srv/a.zip" },
+      onProgress: {
+        onmessage: () => {
+          throw new Error("component unmounted");
+        },
+      },
+    });
+    expect(res).toEqual({ entries: 1 });
+  });
+
+  it("parses SSE blocks the way the Rust parser does", () => {
+    expect(parseSseBlock("event: done\ndata: {}")).toEqual({
+      event: "done",
+      data: "{}",
+    });
+    // Multi-line data joins with newlines; comments and CR are ignored.
+    expect(parseSseBlock(": keepalive\r\nevent: progress\r\ndata: a\r\ndata: b")).toEqual(
+      { event: "progress", data: "a\nb" },
+    );
+    expect(parseSseBlock(": just a comment")).toBeNull();
   });
 });

--- a/client/src/lib/browserInvoke.ts
+++ b/client/src/lib/browserInvoke.ts
@@ -79,6 +79,28 @@ function addrUrl(path: string, addr?: string | null): string {
   return addr && addr.length > 0 ? `${path}?addr=${uenc(addr)}` : path;
 }
 
+/**
+ * Build `path?k=v&…` using the engine's own encoding, skipping params that
+ * are null/undefined/empty-string.
+ *
+ * This mirrors the `let mut params = Vec::new(); … params.join("&")` shape
+ * the Rust commands in `ps5_engine.rs` use, so both transports produce
+ * byte-identical URLs. Numeric `0` and boolean `false` are NOT skipped —
+ * `since_seq=0` is a meaningful cursor, and dropping it would silently
+ * replay the whole notification backlog.
+ */
+function qs(
+  path: string,
+  params: Record<string, string | number | boolean | null | undefined>,
+): string {
+  const parts: string[] = [];
+  for (const [k, v] of Object.entries(params)) {
+    if (v === null || v === undefined || v === "") continue;
+    parts.push(`${k}=${uenc(String(v))}`);
+  }
+  return parts.length > 0 ? `${path}?${parts.join("&")}` : path;
+}
+
 // ── Fetch helpers ─────────────────────────────────────────────────────────────
 
 const TIMEOUT_STANDARD = 60_000; // 60 s — matches Rust http_client
@@ -116,6 +138,124 @@ async function postJson<T>(
   });
   if (!r.ok) throw new Error(await extractEngineError(r));
   return r.json() as Promise<T>;
+}
+
+// ── SSE (streaming archive inspect) ──────────────────────────────────────────
+
+/** Matches `INSPECT_IDLE_TIMEOUT_SECS` in `commands/ps5_engine.rs`. A slow
+ *  network mount or a spun-down USB HDD can go quiet for a long time between
+ *  events; only a truly wedged engine should trip this. */
+const INSPECT_IDLE_TIMEOUT_MS = 30_000;
+
+/** The shape `api/ps5.ts` hands us for progress. In Tauri this is a real
+ *  `Channel`; in the browser we only ever touch `.onmessage`, so we accept
+ *  any object carrying one. */
+type ProgressChannel = { onmessage?: (p: unknown) => void };
+
+/**
+ * Consume the engine's `text/event-stream` inspect endpoints, forwarding
+ * `progress` events to `channel.onmessage` and resolving with the `done`
+ * payload — the browser-side twin of `post_sse_inspect_with_watchdog()`.
+ *
+ * The idle watchdog is the reason this can't just be an `EventSource`:
+ * these endpoints are POSTs with a JSON body, and `EventSource` can only
+ * issue bodyless GETs. Progress delivery is fire-and-forget to match the
+ * Rust side — a throwing callback (e.g. an unmounted component) must not
+ * abort an inspect that is otherwise succeeding.
+ */
+async function postSseInspect<T>(
+  path: string,
+  body: unknown,
+  channel: ProgressChannel | undefined,
+): Promise<T> {
+  const r = await fetch(`${getEngineUrl()}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", accept: "text/event-stream" },
+    body: JSON.stringify(body),
+  });
+  // A non-200 means the engine rejected the request shape outright; stream
+  // errors arrive as a final `event: error` on an otherwise-200 response.
+  if (!r.ok) throw new Error(await extractEngineError(r));
+  if (!r.body) throw new Error("engine returned no SSE body");
+
+  const reader = r.body.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  try {
+    for (;;) {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const idle = new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () =>
+            reject(
+              new Error(
+                `engine stopped responding (no SSE event for ${INSPECT_IDLE_TIMEOUT_MS / 1000}s)`,
+              ),
+            ),
+          INSPECT_IDLE_TIMEOUT_MS,
+        );
+      });
+      let chunk: ReadableStreamReadResult<Uint8Array>;
+      try {
+        chunk = await Promise.race([reader.read(), idle]);
+      } finally {
+        if (timer !== undefined) clearTimeout(timer);
+      }
+      if (chunk.done) {
+        throw new Error(
+          "engine closed the inspect stream before sending a done/error event",
+        );
+      }
+      buf += decoder.decode(chunk.value, { stream: true });
+
+      for (;;) {
+        const m = /\r?\n\r?\n/.exec(buf);
+        if (!m) break;
+        const block = buf.slice(0, m.index);
+        buf = buf.slice(m.index + m[0].length);
+        const ev = parseSseBlock(block);
+        if (!ev) continue;
+        if (ev.event === "progress") {
+          try {
+            channel?.onmessage?.(JSON.parse(ev.data));
+          } catch {
+            /* fire-and-forget, exactly like the Rust Channel::send */
+          }
+        } else if (ev.event === "done") {
+          return JSON.parse(ev.data) as T;
+        } else if (ev.event === "error") {
+          let msg = ev.data;
+          try {
+            const j = JSON.parse(ev.data) as Record<string, unknown>;
+            if (typeof j["error"] === "string") msg = j["error"] as string;
+          } catch {
+            /* fall back to the raw data */
+          }
+          throw new Error(`engine reported: ${msg}`);
+        }
+      }
+    }
+  } finally {
+    await reader.cancel().catch(() => {});
+  }
+}
+
+/** Parse one SSE block into `{ event, data }`, mirroring the Rust
+ *  `parse_sse_block()` — multi-line `data:` fields join with newlines and
+ *  comment lines (`:`) are skipped. Exported for unit tests. */
+export function parseSseBlock(
+  block: string,
+): { event?: string; data: string } | null {
+  let event: string | undefined;
+  const data: string[] = [];
+  for (const raw of block.split("\n")) {
+    const line = raw.replace(/\r+$/, "");
+    if (line === "" || line.startsWith(":")) continue;
+    if (line.startsWith("event:")) event = line.slice(6).replace(/^ +/, "");
+    else if (line.startsWith("data:")) data.push(line.slice(5).replace(/^ +/, ""));
+  }
+  if (event === undefined && data.length === 0) return null;
+  return { event, data: data.join("\n") };
 }
 
 // ── Dispatch ──────────────────────────────────────────────────────────────────
@@ -913,6 +1053,420 @@ export async function browserInvoke<T>(
     case "inspect_folder":
       return getJson<T>(
         `/api/local/inspect-folder?path=${uenc(args["path"] as string)}`,
+      );
+
+    // ── Cheats ───────────────────────────────────────────────────────────────
+    // The whole Cheats screen used to be dead in a self-hosted browser
+    // session: the engine served every one of these routes, but the shim
+    // had no mapping so each button threw BrowserUnsupportedError (#295).
+
+    case "cheats_list":
+      return getJson<T>(
+        qs("/api/ps5/cheats/list", { addr: args["req"]?.addr }),
+      );
+
+    case "cheats_get":
+      return getJson<T>(
+        qs("/api/ps5/cheats/get", {
+          addr: args["req"]?.addr,
+          title_id: args["req"]?.title_id,
+        }),
+      );
+
+    case "cheats_delete":
+      return getJson<T>(
+        qs("/api/ps5/cheats/delete", {
+          addr: args["req"]?.addr,
+          title_id: args["req"]?.title_id,
+        }),
+      );
+
+    case "cheats_reload":
+      return getJson<T>(
+        qs("/api/ps5/cheats/reload", { addr: args["req"]?.addr }),
+      );
+
+    case "cheats_status":
+      return getJson<T>(
+        qs("/api/ps5/cheats/status", { addr: args["req"]?.addr }),
+      );
+
+    case "cheats_toggle":
+      return postJson<T>("/api/ps5/cheats/toggle", {
+        addr: args["req"]?.addr,
+        title_id: args["req"]?.title_id,
+        index: args["req"]?.index,
+        on: args["req"]?.on,
+      });
+
+    case "cheats_engine_set":
+      return postJson<T>("/api/ps5/cheats/engine-set", {
+        addr: args["req"]?.addr,
+        enabled: args["req"]?.enabled,
+      });
+
+    case "cheats_repos_list":
+      return getJson<T>("/api/ps5/cheats/repos/list");
+
+    case "cheats_repos_search":
+      return getJson<T>(
+        qs("/api/ps5/cheats/repos/search", { query: args["req"]?.query }),
+      );
+
+    case "cheats_repos_download":
+      return postJson<T>("/api/ps5/cheats/repos/download", {
+        addr: args["req"]?.addr,
+        repo_id: args["req"]?.repo_id,
+        filename: args["req"]?.filename,
+        title_id: args["req"]?.title_id,
+      });
+
+    // ── Activity / notifications / hardware ──────────────────────────────────
+
+    case "activity_get":
+      return getJson<T>(
+        qs("/api/ps5/activity/get", { addr: args["req"]?.addr }),
+      );
+
+    case "activity_db_query":
+      return getJson<T>(
+        qs("/api/ps5/activity/db-query", {
+          addr: args["req"]?.addr,
+          query: args["req"]?.query,
+        }),
+      );
+
+    case "notif_list":
+      return getJson<T>(
+        qs("/api/ps5/notif/list", {
+          addr: args["req"]?.addr,
+          since_seq: args["req"]?.since_seq ?? 0,
+        }),
+      );
+
+    case "ps5_hw_drive_sensors":
+      return getJson<T>(
+        addrUrl("/api/ps5/hw/drive-sensors", args["addr"] as string | null),
+      );
+
+    case "fan_curve_get":
+      return getJson<T>(
+        qs("/api/ps5/hw/fan-curve/get", { addr: args["req"]?.addr }),
+      );
+
+    case "fan_curve_set":
+      return postJson<T>("/api/ps5/hw/fan-curve", {
+        addr: args["req"]?.addr,
+        points: args["req"]?.points,
+      });
+
+    // ── FTP / firmware spoof / SDK changer ───────────────────────────────────
+
+    case "ftp_start":
+      return postJson<T>("/api/ps5/ftp/start", {
+        addr: args["req"]?.addr,
+        port: args["req"]?.port,
+        root: args["req"]?.root,
+        readonly: args["req"]?.readonly,
+        user: args["req"]?.user,
+        pass: args["req"]?.pass,
+      });
+
+    case "ftp_status":
+      return getJson<T>(qs("/api/ps5/ftp/status", { addr: args["req"]?.addr }));
+
+    case "fw_spoof_status":
+      return getJson<T>(
+        qs("/api/ps5/fw-spoof/status", { addr: args["req"]?.addr }),
+      );
+
+    case "sdk_scan":
+      return getJson<T>(qs("/api/ps5/sdk/scan", { addr: args["req"]?.addr }));
+
+    case "sdk_patch":
+      return postJson<T>("/api/ps5/sdk/patch", {
+        addr: args["req"]?.addr,
+        title_id: args["req"]?.title_id,
+        target_sdk: args["req"]?.target_sdk,
+      });
+
+    case "sdk_restore":
+      return postJson<T>("/api/ps5/sdk/restore", {
+        addr: args["req"]?.addr,
+        title_id: args["req"]?.title_id,
+      });
+
+    case "tmdb_fetch":
+      return getJson<T>(
+        qs("/api/ps5/tmdb/fetch", {
+          addr: args["req"]?.addr,
+          title_id: args["req"]?.title_id,
+          // The Rust side pushes `refresh=true` only when set; a literal
+          // `refresh=false` would be truthy to the engine's string parse.
+          refresh: args["req"]?.refresh ? "true" : undefined,
+          region: args["req"]?.region,
+        }),
+      );
+
+    // ── Users / backup ───────────────────────────────────────────────────────
+
+    case "user_create":
+      return postJson<T>("/api/ps5/users/create", {
+        addr: args["req"]?.addr,
+        name: args["req"]?.name,
+      });
+
+    case "user_delete":
+      return postJson<T>("/api/ps5/users/delete", {
+        addr: args["req"]?.addr,
+        uid: args["req"]?.uid,
+        wipe_saves: args["req"]?.wipe_saves,
+      });
+
+    case "backup_list":
+      return getJson<T>(
+        qs("/api/ps5/backup/list", {
+          addr: args["req"]?.addr,
+          tag: args["req"]?.tag,
+        }),
+      );
+
+    case "backup_snapshot":
+      return postJson<T>(
+        "/api/ps5/backup/snapshot",
+        {
+          addr: args["req"]?.addr,
+          tag: args["req"]?.tag,
+          path: args["req"]?.path,
+        },
+        /*long=*/ true,
+      );
+
+    case "backup_restore":
+      return postJson<T>(
+        "/api/ps5/backup/restore",
+        {
+          addr: args["req"]?.addr,
+          tag: args["req"]?.tag,
+          timestamp: args["req"]?.timestamp,
+        },
+        /*long=*/ true,
+      );
+
+    case "backup_delete":
+      return postJson<T>(
+        "/api/ps5/backup/delete",
+        {
+          addr: args["req"]?.addr,
+          tag: args["req"]?.tag,
+          timestamp: args["req"]?.timestamp,
+        },
+        /*long=*/ true,
+      );
+
+    // ── Package / archive inspection ─────────────────────────────────────────
+
+    case "pkg_metadata":
+      return postJson<T>("/api/pkg/parse", { path: args["path"] });
+
+    case "ffpkg_inspect":
+      return postJson<T>("/api/ffpkg/inspect", { path: args["path"] });
+
+    case "ffpkg_extract":
+      return postJson<T>("/api/ffpkg/extract", {
+        ffpkg_path: args["ffpkgPath"],
+        inner_path: args["innerPath"],
+        dest_dir: args["destDir"],
+      });
+
+    case "zip_inspect":
+      return postJson<T>(
+        "/api/zip/inspect",
+        { zip_path: args["req"]?.zip_path },
+        /*long=*/ true,
+      );
+
+    case "sevenz_inspect":
+      return postJson<T>(
+        "/api/7z/inspect",
+        { archive_path: args["req"]?.archive_path },
+        /*long=*/ true,
+      );
+
+    case "rar_inspect":
+      return postJson<T>(
+        "/api/rar/inspect",
+        {
+          archive_path: args["req"]?.archive_path,
+          password: args["req"]?.password,
+        },
+        /*long=*/ true,
+      );
+
+    case "zip_inspect_stream":
+      return postSseInspect<T>(
+        "/api/zip/inspect/stream",
+        { zip_path: args["req"]?.zip_path },
+        args["onProgress"] as ProgressChannel | undefined,
+      );
+
+    case "sevenz_inspect_stream":
+      return postSseInspect<T>(
+        "/api/7z/inspect/stream",
+        { archive_path: args["req"]?.archive_path },
+        args["onProgress"] as ProgressChannel | undefined,
+      );
+
+    case "bps_inspect":
+      return postJson<T>("/api/bps/inspect", {
+        patch_path: args["req"]?.patch_path,
+      });
+
+    case "bps_apply":
+      return postJson<T>(
+        "/api/bps/apply",
+        {
+          source_path: args["req"]?.source_path,
+          patch_path: args["req"]?.patch_path,
+          dest_path: args["req"]?.dest_path,
+        },
+        /*long=*/ true,
+      );
+
+    // ── Profile avatar ───────────────────────────────────────────────────────
+
+    case "profile_avatar_preview":
+      return postJson<T>("/api/profile/avatar/preview", {
+        image_path: args["req"]?.image_path,
+        mode: args["req"]?.mode,
+      });
+
+    case "profile_apply_avatar":
+      return postJson<T>(
+        "/api/profile/avatar",
+        {
+          addr: args["req"]?.addr,
+          image_path: args["req"]?.image_path,
+          mode: args["req"]?.mode,
+          uid: args["req"]?.uid,
+          username: args["req"]?.username,
+        },
+        /*long=*/ true,
+      );
+
+    // ── SMB ──────────────────────────────────────────────────────────────────
+    // `smb_download_file` is deliberately absent: it writes the fetched bytes
+    // to a host path via `resolve_save_dest()`, which has no browser meaning.
+
+    case "smb_list_shares":
+      return postJson<T>("/api/smb/list-shares", {
+        server: args["req"]?.server,
+        user: args["req"]?.user,
+        password: args["req"]?.password,
+      });
+
+    case "smb_list_dir":
+      return postJson<T>("/api/smb/list-dir", {
+        server: args["req"]?.server,
+        user: args["req"]?.user,
+        password: args["req"]?.password,
+        share: args["req"]?.share,
+        path: args["req"]?.path,
+      });
+
+    case "smb_transfer":
+      return postJson<T>("/api/smb/transfer", {
+        server: args["req"]?.server,
+        user: args["req"]?.user,
+        password: args["req"]?.password,
+        share: args["req"]?.share,
+        path: args["req"]?.path,
+        dest_root: args["req"]?.dest_root,
+        addr: args["req"]?.addr,
+        bandwidth_cap_mbps: args["req"]?.bandwidth_cap_mbps,
+      });
+
+    // ── Transfers ────────────────────────────────────────────────────────────
+    // Paths here are the ENGINE's filesystem, not the browser's. On a
+    // self-hosted engine that is the point: the server holds the library and
+    // the browser is only the remote control.
+
+    case "transfer_zip":
+      return postJson<T>(
+        "/api/transfer/zip",
+        {
+          zip_path: args["req"]?.zip_path,
+          dest_root: args["req"]?.dest_root,
+          addr: args["req"]?.addr,
+          tx_id: args["req"]?.tx_id,
+          excludes: args["req"]?.excludes,
+          bandwidth_cap_mbps: args["req"]?.bandwidth_cap_mbps,
+        },
+        /*long=*/ true,
+      );
+
+    case "transfer_7z":
+      return postJson<T>(
+        "/api/transfer/7z",
+        {
+          archive_path: args["req"]?.archive_path,
+          dest_root: args["req"]?.dest_root,
+          addr: args["req"]?.addr,
+          tx_id: args["req"]?.tx_id,
+          excludes: args["req"]?.excludes,
+          bandwidth_cap_mbps: args["req"]?.bandwidth_cap_mbps,
+        },
+        /*long=*/ true,
+      );
+
+    case "transfer_rar":
+      return postJson<T>(
+        "/api/transfer/rar",
+        {
+          archive_path: args["req"]?.archive_path,
+          dest_root: args["req"]?.dest_root,
+          addr: args["req"]?.addr,
+          tx_id: args["req"]?.tx_id,
+          excludes: args["req"]?.excludes,
+          bandwidth_cap_mbps: args["req"]?.bandwidth_cap_mbps,
+          password: args["req"]?.password,
+        },
+        /*long=*/ true,
+      );
+
+    case "transfer_download":
+      return postJson<T>("/api/transfer/download", {
+        src_path: args["req"]?.src_path,
+        dest_dir: args["req"]?.dest_dir,
+        addr: args["req"]?.addr,
+        kind: args["req"]?.kind,
+        unsafe_read: args["req"]?.unsafe_read,
+      });
+
+    case "transfer_download_zip":
+      return postJson<T>("/api/transfer/download-zip", {
+        src_path: args["req"]?.src_path,
+        dest_zip: args["req"]?.dest_zip,
+        addr: args["req"]?.addr,
+        kind: args["req"]?.kind,
+        unsafe_read: args["req"]?.unsafe_read,
+      });
+
+    case "transfer_dir_diff_preview":
+      return postJson<T>("/api/transfer/dir-diff-preview", {
+        src_dir: args["srcDir"],
+        dest_root: args["destRoot"],
+        addr: args["addr"],
+        excludes: args["excludes"],
+      });
+
+    // ── Reachability ─────────────────────────────────────────────────────────
+
+    case "port_check":
+      // The desktop client opens the socket itself; a browser borrows the
+      // engine's, which is on the console's LAN even when the browser is not.
+      return getJson<T>(
+        qs("/api/ps5/port-check", { ip: args["ip"], port: args["port"] }),
       );
 
     // ── Native-only / unsupported ────────────────────────────────────────────

--- a/client/src/lib/browserInvokeCoverage.test.ts
+++ b/client/src/lib/browserInvokeCoverage.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Coverage gate between the Tauri command surface and the browser shim.
+ *
+ * `browserInvoke.ts` is a hand-maintained switch with no compile-time link
+ * to the `#[tauri::command]` list, so the two drift silently: a command
+ * added on the Rust side simply falls through to `default:` and throws
+ * BrowserUnsupportedError the first time a self-hosted user clicks the
+ * button. That is how the whole Cheats/SMB/Backup/SDK surface came to be
+ * dead in the web UI while the engine was serving every route (#295).
+ *
+ * This test makes that drift a CI failure: every command must be either
+ * mapped in the shim or listed below with a reason it cannot be.
+ */
+import { describe, it, expect } from "vitest";
+
+// Read both sides as raw text at transform time. `import.meta.glob` keeps
+// this dependency-free — the client has no @types/node, and pulling it in
+// just to stat two directories would be a poor trade.
+const COMMAND_SOURCES = import.meta.glob("../../src-tauri/src/commands/*.rs", {
+  query: "?raw",
+  import: "default",
+  eager: true,
+}) as Record<string, string>;
+
+const SHIM_SOURCE = Object.values(
+  import.meta.glob("./browserInvoke.ts", {
+    query: "?raw",
+    import: "default",
+    eager: true,
+  }) as Record<string, string>,
+)[0];
+
+/**
+ * Commands with no browser equivalent, and why. Two kinds live here:
+ *
+ *  - "native": touches the local machine (host filesystem, OS APIs, the
+ *    desktop app's own data dirs). A browser has no such thing.
+ *  - "direct-socket": the desktop client opens a TCP connection straight
+ *    to the console rather than going through the engine. A browser cannot
+ *    open raw sockets, so these need a NEW ENGINE ROUTE before they can
+ *    ever be mapped — adding a shim case would not help.
+ *
+ * Adding a command here is a deliberate statement that the web UI must
+ * hide the affordance (see `hideInBrowser` in `layout/navItems.ts` and the
+ * `isTauriEnv()` guards at the call sites).
+ */
+const NATIVE_ONLY: Record<string, string> = {
+  // Host filesystem / OS
+  read_text_file: "native: reads a host path",
+  save_text_file: "native: writes a host path",
+  save_archive_zip: "native: host temp-dir staging",
+  save_archive_unzip: "native: host temp-dir staging",
+  save_archive_make_temp: "native: host temp-dir staging",
+  save_archive_cleanup_temp: "native: host temp-dir staging",
+  save_archive_backup_finalize: "native: host temp-dir staging",
+  save_archive_restore_prepare: "native: host temp-dir staging",
+  screenshot_save: "native: writes to the app's screenshot dir",
+  screenshot_list: "native: reads the app's screenshot dir",
+  screenshot_delete: "native: deletes from the app's screenshot dir",
+  screenshot_clear: "native: clears the app's screenshot dir",
+  screenshot_open_dir: "native: opens a host file manager",
+  screenshot_convert: "native: host image transcode into a temp dir",
+  smb_download_file: "native: writes the fetched bytes to a host path",
+  usb_list_removable: "native: enumerates host block devices",
+  usb_autoloader_install: "native: writes to a host USB volume",
+  fs_index_start: "native: indexes the host filesystem",
+  fs_index_cancel: "native: indexes the host filesystem",
+  fs_index_status: "native: indexes the host filesystem",
+  fs_search_index: "native: searches the host filesystem index",
+  fs_blake3_hash: "native: hashes a host file",
+  crc32_file_get: "native: hashes a host file",
+
+  // Desktop app data / lifecycle
+  user_config_load: "native: desktop config file mirror (localStorage in browser)",
+  user_config_save: "native: desktop config file mirror (localStorage in browser)",
+  user_config_path_resolved: "native: desktop config file path",
+  app_data_reset: "native: wipes the desktop app data dir",
+  engine_url_get: "native: desktop sidecar URL",
+  engine_url_set: "native: desktop sidecar URL",
+  toast_push: "native: OS notification",
+  keep_awake_set: "native: OS power assertion",
+  keep_awake_state: "native: OS power assertion",
+  keep_awake_acquire: "native: OS power assertion",
+  keep_awake_release: "native: OS power assertion",
+  acquire_multicast_lock: "native: Android Wi-Fi multicast lock",
+  release_multicast_lock: "native: Android Wi-Fi multicast lock",
+  update_check: "native: desktop self-update",
+  update_download: "native: desktop self-update",
+  changelog_load: "native: reads a bundled resource",
+  faq_load: "native: reads a bundled resource",
+
+  // Diagnostics / crash reporting (all host-side files)
+  crash_report_save: "native: writes the crash-report dir",
+  crash_reports_clear: "native: writes the crash-report dir",
+  crash_reports_dir_resolved: "native: host path",
+  crash_reports_open_dir: "native: opens a host file manager",
+  crash_reports_stats: "native: reads the crash-report dir",
+  crash_reports_zip: "native: zips the crash-report dir",
+  bug_report_build: "native: assembles a host-side bundle",
+  diag_log_append: "native: writes the host diag log",
+  diag_log_clear: "native: writes the host diag log",
+  diag_log_read_window: "native: reads the host diag log",
+  diag_log_stats: "native: reads the host diag log",
+  diag_log_open_dir: "native: opens a host file manager",
+
+  // Desktop-side persistence (browser uses localStorage)
+  // These two DO run in the browser — api/ps5.ts falls back to
+  // localStorage before it ever reaches the shim, so the Tauri command
+  // stays desktop-only while the feature still works in a browser.
+  upload_queue_load: "native: desktop queue file (browser uses localStorage)",
+  upload_queue_save: "native: desktop queue file (browser uses localStorage)",
+  payload_playlists_load: "native: desktop playlist file",
+  payload_playlists_save: "native: desktop playlist file",
+  send_payload_history_load: "native: desktop history file",
+  send_payload_history_add: "native: desktop history file",
+  send_payload_history_clear: "native: desktop history file",
+  resume_txid_lookup: "native: desktop resume-state file",
+  resume_txid_remember: "native: desktop resume-state file",
+  resume_txid_forget: "native: desktop resume-state file",
+
+  // Payload catalogue: downloads ELFs to host disk, then sends them over a
+  // raw socket. The whole /payloads nav entry is hideInBrowser.
+  payloads_catalog: "native: caches the catalogue on host disk",
+  payloads_releases: "native: talks to the GitHub API from the client",
+  payloads_release: "native: talks to the GitHub API from the client",
+  payloads_download: "native: downloads an ELF to host disk",
+  payloads_local_inventory: "native: reads the host payload dir",
+  payloads_local_path: "native: host path",
+  payloads_add_custom_repo: "native: desktop repo-config file",
+  payloads_remove_custom_repo: "native: desktop repo-config file",
+  payload_bundled_path: "native: path of an ELF bundled in the desktop app",
+
+  // Direct TCP to the console — need an engine route before they can work
+  payload_probe: "direct-socket: probes the console's mgmt port",
+  payload_send: "direct-socket: writes an ELF to the console's loader port",
+  companion_probe: "direct-socket: raw TCP connect probe",
+  discover_ps5: "direct-socket: mDNS multicast",
+  peripheral_eject: "direct-socket: console mgmt port",
+  peripheral_bd_on: "direct-socket: console mgmt port",
+  peripheral_bd_off: "direct-socket: console mgmt port",
+  peripheral_usb_on: "direct-socket: console mgmt port",
+  peripheral_usb_off: "direct-socket: console mgmt port",
+  ufs_fsck_run: "direct-socket: console mgmt port",
+  lwfs_mount_run: "direct-socket: console mgmt port",
+  pkg_direct_mount_run: "direct-socket: console mgmt port",
+  proc_modules_get: "direct-socket: console mgmt port",
+  shell_run_cmd: "direct-socket: console mgmt port",
+  net_speed_test_run: "direct-socket: console mgmt port",
+  appdb_query_get: "direct-socket: console mgmt port",
+  heal_appmeta: "direct-socket: console mgmt port",
+  title_meta_fetch: "native: fetches artwork over https from the client",
+};
+
+function tauriCommands(): string[] {
+  const names: string[] = [];
+  for (const src of Object.values(COMMAND_SOURCES)) {
+    const lines = src.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      if (!lines[i].includes("#[tauri::command]")) continue;
+      // The attribute and the fn can be separated by doc comments or
+      // other attributes; the fn is always within a few lines.
+      for (let j = i + 1; j < Math.min(i + 5, lines.length); j++) {
+        const m = /(?:pub\s+)?(?:async\s+)?fn\s+(\w+)/.exec(lines[j]);
+        if (m) {
+          names.push(m[1]);
+          break;
+        }
+      }
+    }
+  }
+  return [...new Set(names)].sort();
+}
+
+function mappedCommands(): Set<string> {
+  return new Set(
+    [...SHIM_SOURCE.matchAll(/^\s+case "([a-z0-9_]+)":/gm)].map((m) => m[1]),
+  );
+}
+
+describe("browser shim covers the Tauri command surface", () => {
+  const commands = tauriCommands();
+  const mapped = mappedCommands();
+
+  it("finds both sides (guards against a broken parse)", () => {
+    expect(commands.length).toBeGreaterThan(200);
+    expect(mapped.size).toBeGreaterThan(100);
+  });
+
+  it("every command is either mapped or documented as native-only", () => {
+    const undeclared = commands.filter(
+      (c) => !mapped.has(c) && !(c in NATIVE_ONLY),
+    );
+    expect(
+      undeclared,
+      `These Tauri commands are unreachable from the browser and undocumented.\n` +
+        `Either add a case to browserInvoke.ts (if the engine serves a route for it)\n` +
+        `or add it to NATIVE_ONLY with a reason:\n  ${undeclared.join("\n  ")}`,
+    ).toEqual([]);
+  });
+
+  it("the native-only list has no stale entries", () => {
+    const known = new Set(commands);
+    // A command that is both mapped and listed native-only is a
+    // contradiction; one that no longer exists is dead weight.
+    const stale = Object.keys(NATIVE_ONLY).filter(
+      (c) => !known.has(c) || mapped.has(c),
+    );
+    expect(
+      stale,
+      `Stale NATIVE_ONLY entries (command gone, or now mapped): ${stale.join(", ")}`,
+    ).toEqual([]);
+  });
+});

--- a/client/src/screens/Connection/index.tsx
+++ b/client/src/screens/Connection/index.tsx
@@ -592,7 +592,11 @@ export default function ConnectionScreen() {
             running payload. Once step2 is "ok" they don't need it.
             One-click path; falls through to this manual flow if they
             prefer it. */}
-        {step2 !== "ok" && (
+        {/* Browser: /first-run is a NativeOnlyRoute — the wizard downloads
+            payload ELFs to the host and sends them over a raw socket, so
+            it bounces straight back here. Offering the button anyway just
+            makes the page look broken. */}
+        {step2 !== "ok" && isTauriEnv() && (
           <div className="flex flex-wrap items-start gap-3 rounded-md border border-[var(--color-accent)] bg-[var(--color-surface-2)] p-3 text-xs">
             <Sparkles
               size={14}

--- a/client/src/screens/SmbBrowser/index.tsx
+++ b/client/src/screens/SmbBrowser/index.tsx
@@ -24,6 +24,7 @@ import { useTr } from "../../state/lang";
 import { useConnectionStore } from "../../state/connection";
 import { transferAddr } from "../../lib/addr";
 import { humanizePs5Error } from "../../lib/humanizeError";
+import { isTauriEnv } from "../../lib/tauriEnv";
 import {
   smbListShares,
   smbListDir,
@@ -467,7 +468,10 @@ export default function SmbBrowserScreen() {
                           {formatSize(e.size)}
                         </span>
                       )}
-                      {!e.is_dir && (
+                      {/* Download saves to THIS computer via the native file
+                          dialog, so it exists only in the desktop app. Uploading
+                          to the PS5 (below) is engine-side and works anywhere. */}
+                      {!e.is_dir && isTauriEnv() && (
                         <button
                           className="shrink-0 rounded p-1.5 text-[var(--color-muted)] transition-colors hover:bg-[var(--color-surface-3)] hover:text-[var(--color-text)]"
                           onClick={(ev) => {

--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -48,6 +48,13 @@ RUN apk add --no-cache musl-dev g++ make
 WORKDIR /build
 COPY engine engine
 COPY third_party third_party
+# The PS5 helper ELFs the engine embeds (build.rs looks for them at
+# <repo root>/payload). Without this the image builds fine but installs
+# UPDATES and DLC with no installer to send — the exact #295 failure —
+# because `have_bundled_dpi` is never set. ezremote-dpi.elf is committed,
+# so this always works; ps5upload.elf appears only if you ran
+# `make payload` first (it needs the PS5 payload SDK).
+COPY payload payload
 WORKDIR /build/engine
 RUN cargo build --release -p ps5upload-engine
 

--- a/engine/Dockerfile.webui
+++ b/engine/Dockerfile.webui
@@ -57,6 +57,9 @@ RUN apk add --no-cache musl-dev g++ make
 WORKDIR /build
 COPY engine/ ./engine/
 COPY third_party/ ./third_party/
+# See engine/Dockerfile: build.rs embeds these, and the web UI's update /
+# DLC install is exactly what breaks without them (#295).
+COPY payload/ ./payload/
 WORKDIR /build/engine
 
 # Populate the webui/ embed directory from the frontend build output.

--- a/engine/crates/ps5upload-core/src/payload_lifecycle.rs
+++ b/engine/crates/ps5upload-core/src/payload_lifecycle.rs
@@ -109,6 +109,30 @@ pub fn port_is_open(addr: &str, timeout: Duration) -> bool {
         .any(|sa| TcpStream::connect_timeout(sa, timeout).is_ok())
 }
 
+/// Probe `host:port`, keeping "the name never resolved" distinct from
+/// "nothing answered".
+///
+/// The desktop client's `port_check` learned to separate these in #272:
+/// collapsing them made a DNS typo read as "your PS5 isn't jailbroken".
+/// The browser has no sockets of its own, so a self-hosted web UI has to
+/// borrow the engine's — and the engine is the better prober anyway, since
+/// it sits on the console's LAN while the browser may not.
+pub fn probe_port(host: &str, port: u16, timeout: Duration) -> Result<(), String> {
+    let addr = join_host_port(host, port);
+    let targets = resolve_connect_targets(&addr).map_err(|e| format!("resolve {host}: {e}"))?;
+    if targets.is_empty() {
+        return Err(format!("resolve {host}: no addresses"));
+    }
+    let mut last = String::from("no addresses to try");
+    for sa in &targets {
+        match TcpStream::connect_timeout(sa, timeout) {
+            Ok(_) => return Ok(()),
+            Err(e) => last = format!("connect {sa}: {e}"),
+        }
+    }
+    Err(last)
+}
+
 /// What is being loaded, which decides whether a payload already running
 /// on the console has to be shut down first.
 ///
@@ -311,5 +335,31 @@ mod tests {
             "198.51.100.1:9040",
             Duration::from_millis(300)
         ));
+    }
+
+    #[test]
+    fn probe_port_separates_a_bad_name_from_a_dead_host() {
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        assert!(probe_port("127.0.0.1", port, Duration::from_secs(2)).is_ok());
+
+        // A name that cannot resolve and a host that never answers are
+        // different problems, and the Connection screen says so (#272).
+        // Collapsing them is what made a typo read as "not jailbroken".
+        let unresolvable = probe_port("no-such-host.invalid", 9113, Duration::from_millis(300))
+            .expect_err("should not resolve");
+        assert!(
+            unresolvable.starts_with("resolve "),
+            "want a resolve error, got: {unresolvable}"
+        );
+
+        let unreachable = probe_port("198.51.100.1", 9113, Duration::from_millis(300))
+            .expect_err("nothing listens on TEST-NET-2");
+        assert!(
+            unreachable.starts_with("connect "),
+            "want a connect error, got: {unreachable}"
+        );
     }
 }

--- a/engine/crates/ps5upload-engine/src/lib.rs
+++ b/engine/crates/ps5upload-engine/src/lib.rs
@@ -8293,6 +8293,53 @@ async fn debug_crash(Query(q): Query<DebugCrashQuery>) -> axum::response::Respon
     }
 }
 
+/// GET /api/ps5/port-check?ip=&port= — TCP reachability probe.
+///
+/// Exists so the self-hosted web UI can light up the same connection
+/// status dots the desktop client does. A browser cannot open a raw
+/// socket, so without this the Connection screen and the first-run
+/// reachability step were both dead in a browser session (#295).
+///
+/// Mirrors the `port_check` Tauri command's shape exactly —
+/// `{ open: bool, error: string|null }` — so the two transports stay
+/// interchangeable behind `portProbe()`.
+async fn ps5_port_check(Query(q): Query<PortCheckQuery>) -> impl IntoResponse {
+    let ip = q.ip.trim().to_string();
+    if ip.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "open": false, "error": "ip is required" })),
+        );
+    }
+    let timeout = Duration::from_millis(q.timeout_ms.unwrap_or(1500).clamp(100, 10_000));
+    let res = tokio::task::spawn_blocking(move || {
+        ps5upload_core::payload_lifecycle::probe_port(&ip, q.port, timeout)
+    })
+    .await;
+    match res {
+        Ok(Ok(())) => (
+            StatusCode::OK,
+            Json(serde_json::json!({ "open": true, "error": null })),
+        ),
+        Ok(Err(e)) => (
+            StatusCode::OK,
+            Json(serde_json::json!({ "open": false, "error": e })),
+        ),
+        Err(e) => (
+            StatusCode::OK,
+            Json(serde_json::json!({ "open": false, "error": format!("probe task: {e}") })),
+        ),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct PortCheckQuery {
+    ip: String,
+    port: u16,
+    /// Optional override so a slow LAN can be probed more patiently.
+    timeout_ms: Option<u64>,
+}
+
 /// GET /api/version — engine self-identification.
 ///
 /// Returned shape: `{"version": "x.y.z"}`. Used by the Tauri shell
@@ -8524,6 +8571,7 @@ async fn run(cfg: EngineConfig) -> anyhow::Result<()> {
     let app = Router::new()
         .route("/", get(ui_handler))
         .route("/api/ps5/status", get(ps5_status))
+        .route("/api/ps5/port-check", get(ps5_port_check))
         .route("/api/ps5/readiness", get(ps5_readiness))
         .route("/api/ps5/health/scan", get(health_scan_handler))
         .route("/api/ps5/health/junk", get(health_junk_handler))


### PR DESCRIPTION
## What this is

The #295 fix made update installs work from the self-hosted web UI. This closes the rest of the same gap.

`client/src/lib/browserInvoke.ts` translates each Tauri command into an engine request, and nothing keeps that switch in step with the `#[tauri::command]` list. It had drifted to **103 of 243** commands; everything else hit `default:` and threw `BrowserUnsupportedError` the first time a self-hosted user pressed the button.

## What was broken

**54 unmapped commands were plain HTTP proxies to routes the engine already served.** Probed against a live engine: 0 of 17 routes returned 404 (only 502 "no console" / 422 "bad body"). So these screens rendered normally in a browser and failed on click:

| Screen | Was dead in the browser |
|---|---|
| Cheats | the entire screen |
| SMB Browser | list-shares, list-dir, transfer |
| Backup | list, snapshot, restore, delete |
| SDK Changer | scan, patch, restore |
| Game Activity, Notifications, FTP, Fan Curve, FW Spoof | all |
| Hardware | drive sensors |
| Upload | ffpkg inspect/extract, dir-diff-preview, transfer_zip |
| FileSystem / Library / Saves / Screenshots / Videos | download, download-zip |
| Fakelib, Profile | bps inspect/apply, avatar apply |

Only one nav item declared `hideInBrowser`, so nothing hid these.

The two SSE inspect endpoints needed a real stream reader rather than a mapping — they're POSTs with a body, and `EventSource` can only issue bodyless GETs.

## New engine route

`port_check` had no engine route at all (the desktop client opens the socket itself), so the Connect screen couldn't tell whether a PS5 was reachable. Added `GET /api/ps5/port-check`, preserving #272's resolve-vs-connect distinction. The engine is the better prober anyway — it's on the console's network, the browser may not be.

## Two more browser-only defects this surfaced

- **"Save failed" on a successful install.** Every upload-queue mutation called the Tauri-only `upload_queue_save`; the Upload screen rendered the throw as *"Queue changes could not be saved — free disk space or fix permissions"* over installs that had actually succeeded. The queue now lives in `localStorage` and survives a reload.
- **Self-built Docker images shipped without the on-console installer.** Neither Dockerfile copied `payload/` into the build context, and the staging dir is gitignored, so `build.rs` found neither helper ELF. Any self-built image installed base games but turned every update away — the exact bug 5.16.0 set out to fix. Only CI-built images escaped, because the workflow stages the ELFs before `docker build`.

## Keeping it fixed

`browserInvokeCoverage.test.ts` fails CI if a command is neither mapped nor listed as native-only **with a reason**. It caught a bogus entry on its first run. The native-only list distinguishes "touches the host" from "opens a raw socket to the console" — the latter need new engine routes before they could ever be mapped.

## Verification

Hardware, both consoles, real PS4 base + patch pair (`CUSA03474`, 556 MB `PS4GD` + 15 MB `PS4DP`):

| | FW 5.10 (.99) | FW 9.60 (.100) |
|---|---|---|
| uninstall → base install | ✅ | ✅ |
| update install | ✅ `APP_VER 01.00 → 01.02` | ✅ `APP_VER 01.00 → 01.02` |
| driven through | real browser, web UI | web UI served by a locally built Docker image |

- Patch routed to `pkg_library/updates/`; queue reported **2 done / 0 failed**; no `BrowserUnsupportedError` anywhere in the session.
- Docker image built from this branch answers `dpi-ensure` by *attempting the send* instead of "no DPI install daemon bundled" — and the same image drove a real console end to end.
- Gates: `cargo fmt --check`, `clippy -D warnings`, `cargo test --workspace` all clean; client typecheck + eslint clean; **113 files / 1197 tests** pass (20 new).

### Caveat

Neither of my consoles is on FW 11, where the in-process path rejects patches. On 5.10/9.60 the patch is accepted in-process (`via: in-proc-appinst`), so the DPI fallback isn't reached by these runs; its routes were verified directly against hardware instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ao1RVsoPJp4hQywWgq3bJr