### PR TITLE
docs: point the web UI install comments at #152, not #295

### DIFF
--- a/.github/workflows/docker-engine.yml
+++ b/.github/workflows/docker-engine.yml
@@ -17,7 +17,7 @@ name: docker-engine
 # DPI daemon up and put the helper back afterwards — the fallback that
 # installs a game PATCH. The desktop client does this from its own embeds;
 # a browser has no socket and no bytes, so without them the web UI could
-# install base games and nothing else (issue #295). That is why the tag
+# install base games and nothing else (the web UI half of #152). That is why the tag
 # builds now start with a `build-payload` job: the main payload is not
 # committed (see .gitignore) and needs the PS5 payload SDK.
 #

--- a/client/src/api/ps5.ts
+++ b/client/src/api/ps5.ts
@@ -813,7 +813,7 @@ export async function uploadQueueLoad<T = unknown>(): Promise<T> {
  *  In the browser this used to throw BrowserUnsupportedError on every
  *  queue mutation, which the Upload screen surfaced as a red "Save
  *  failed — free disk space or fix permissions" banner on an install
- *  that had in fact succeeded (#295). */
+ *  that had in fact succeeded (#300). */
 export async function uploadQueueSave(doc: unknown): Promise<void> {
   if (!isTauriEnv()) {
     try {

--- a/client/src/api/uploadQueuePersistence.test.ts
+++ b/client/src/api/uploadQueuePersistence.test.ts
@@ -5,7 +5,7 @@
  * Tauri-only `upload_queue_save`, which threw BrowserUnsupportedError.
  * The Upload screen caught it and rendered "Save failed — free disk space
  * or fix permissions" over an install that had actually succeeded, which
- * is how it showed up in the #295 hardware run.
+ * is how it showed up in the #300 hardware run.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 

--- a/client/src/lib/browserInvoke.test.ts
+++ b/client/src/lib/browserInvoke.test.ts
@@ -66,7 +66,7 @@ describe("timeSyncBody", () => {
  * game. On the desktop the fallback works because the app embeds both
  * ELF images and streams them to the loader itself.
  *
- * A browser can do neither. Before #295 `dpi_ensure` had no entry in
+ * A browser can do neither. Before the web UI fix `dpi_ensure` had no entry in
  * this map, so it threw BrowserUnsupportedError, the cascade recorded
  * "daemon failed", and every update installed from the web UI died with
  * the generic "this update couldn't be applied" hint — while base games,
@@ -133,7 +133,7 @@ describe("loader-port commands the DPI fallback depends on", () => {
   });
 });
 
-describe("engine-backed commands the web UI depends on (#295 follow-up)", () => {
+describe("engine-backed commands the web UI depends on (#300)", () => {
   beforeEach(() => {
     vi.unstubAllGlobals();
   });

--- a/client/src/lib/browserInvoke.ts
+++ b/client/src/lib/browserInvoke.ts
@@ -764,7 +764,7 @@ export async function browserInvoke<T>(
     // copy of the bytes, so the engine does it. Missing here, the install
     // cascade's DPI fallback was unreachable from the web UI — and that
     // fallback is the only path that lands a game PATCH, which is why
-    // base games installed from the browser and updates did not (#295).
+    // base games installed from the browser and updates did not (#152).
     case "dpi_ensure":
       // TS caller: { ip }. Response shape matches the Tauri command's
       // { ok, listening, sent, error? } — the cascade reads `sent` to
@@ -1058,7 +1058,7 @@ export async function browserInvoke<T>(
     // ── Cheats ───────────────────────────────────────────────────────────────
     // The whole Cheats screen used to be dead in a self-hosted browser
     // session: the engine served every one of these routes, but the shim
-    // had no mapping so each button threw BrowserUnsupportedError (#295).
+    // had no mapping so each button threw BrowserUnsupportedError (#300).
 
     case "cheats_list":
       return getJson<T>(

--- a/client/src/lib/browserInvokeCoverage.test.ts
+++ b/client/src/lib/browserInvokeCoverage.test.ts
@@ -6,7 +6,7 @@
  * added on the Rust side simply falls through to `default:` and throws
  * BrowserUnsupportedError the first time a self-hosted user clicks the
  * button. That is how the whole Cheats/SMB/Backup/SDK surface came to be
- * dead in the web UI while the engine was serving every route (#295).
+ * dead in the web UI while the engine was serving every route (#300).
  *
  * This test makes that drift a CI failure: every command must be either
  * mapped in the shim or listed below with a reason it cannot be.

--- a/client/src/state/pkgLibrary.ts
+++ b/client/src/state/pkgLibrary.ts
@@ -987,7 +987,7 @@ const PKG_STALL_HINT =
  *  brought up. Distinct from `PKG_PATCH_REJECTED_HINT` on purpose: saying
  *  "the PS5 declined it" when the console never saw the request sends
  *  people hunting for the wrong base-game version. The common cause on a
- *  self-hosted engine is a build with no bundled daemon image (#295). */
+ *  self-hosted engine is a build with no bundled daemon image (#152). */
 export const PKG_PATCH_DAEMON_UNAVAILABLE_HINT =
   "This update couldn’t be applied because ps5upload couldn’t start the PS5’s update installer, so the console never saw the update. Your base game is untouched. If you’re running a self-hosted engine, use the released engine build (or the ps5upload-engine Docker image) — a source build without the PS5 payload SDK has no installer image to send. You can also apply the update from the PS5 itself: Settings → System → Debug Settings → Game → Package Installer.";
 
@@ -1188,7 +1188,7 @@ async function restoreMainPayload(ip: string): Promise<void> {
       // `payload_bundled_path`/`payload_send` are desktop-only commands —
       // calling them here threw BrowserUnsupportedError, which is what
       // made the whole DPI fallback (and therefore every patch install)
-      // fail from the web UI. See #295.
+      // fail from the web UI. See #152.
       const r = (await invoke("payload_restore", { ip })) as {
         ok?: boolean;
         error?: string;

--- a/client/src/state/pkgLibraryBrowser.test.ts
+++ b/client/src/state/pkgLibraryBrowser.test.ts
@@ -10,7 +10,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
  * threw `BrowserUnsupportedError` before it ever reached the daemon. Base
  * games, which land on the in-process tier and never need the fallback,
  * kept working, which is why the report was "updates fail from the web UI
- * but install fine from the Windows app" (#295).
+ * but install fine from the Windows app" — the web UI half of #152.
  */
 vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
 vi.mock("../lib/tauriEnv", () => ({ isTauriEnv: () => false }));

--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -50,7 +50,7 @@ COPY engine engine
 COPY third_party third_party
 # The PS5 helper ELFs the engine embeds (build.rs looks for them at
 # <repo root>/payload). Without this the image builds fine but installs
-# UPDATES and DLC with no installer to send — the exact #295 failure —
+# UPDATES and DLC with no installer to send — the exact #152 failure —
 # because `have_bundled_dpi` is never set. ezremote-dpi.elf is committed,
 # so this always works; ps5upload.elf appears only if you ran
 # `make payload` first (it needs the PS5 payload SDK).

--- a/engine/Dockerfile.webui
+++ b/engine/Dockerfile.webui
@@ -25,7 +25,7 @@
 # The image also carries the two PS5 helper ELFs (ps5upload.elf and the DPI
 # install daemon). The browser cannot open a socket to the console's loader
 # or hold those bytes itself, so without them the web UI can install base
-# games but not updates or DLC (issue #295). Override with
+# games but not updates or DLC — the web UI half of #152. Override with
 # PS5UPLOAD_PAYLOAD_DIR if you need to pin different ones.
 #
 # SECURITY: the web UI is UNAUTHENTICATED.  Anyone whose IP is in
@@ -58,7 +58,7 @@ WORKDIR /build
 COPY engine/ ./engine/
 COPY third_party/ ./third_party/
 # See engine/Dockerfile: build.rs embeds these, and the web UI's update /
-# DLC install is exactly what breaks without them (#295).
+# DLC install is exactly what breaks without them (the web UI half of #152).
 COPY payload/ ./payload/
 WORKDIR /build/engine
 

--- a/engine/crates/ps5upload-core/src/payload_lifecycle.rs
+++ b/engine/crates/ps5upload-core/src/payload_lifecycle.rs
@@ -166,7 +166,7 @@ pub enum LoaderImage {
 /// It exists because the install cascade's DPI fallback — the only path
 /// that lands a game *patch* — needs to load a daemon onto the console,
 /// and a browser can neither open a TCP socket nor reach the desktop
-/// client's embedded copy of that daemon (issue #295).
+/// client's embedded copy of that daemon (the web UI half of #152).
 ///
 /// Whether to shut a running payload down before streaming these bytes.
 ///

--- a/engine/crates/ps5upload-engine/build.rs
+++ b/engine/crates/ps5upload-engine/build.rs
@@ -5,7 +5,7 @@
 //! sends them itself, but a browser driving a self-hosted engine cannot —
 //! it has no TCP socket and no copy of the bytes. Without them the install
 //! cascade's DPI fallback (the only path that lands a game *patch*) is
-//! unreachable from the web UI, which is issue #295.
+//! unreachable from the web UI — the web UI half of #152.
 //!
 //! Both embeds are OPTIONAL, mirroring the desktop client's `have_dpi`
 //! gate: the images are produced by `make payload` and need the PS5 payload

--- a/engine/crates/ps5upload-engine/src/bundled_payload.rs
+++ b/engine/crates/ps5upload-engine/src/bundled_payload.rs
@@ -6,7 +6,7 @@
 //! module the web UI could not bring up the DPI install daemon, and the
 //! install cascade's DPI fallback was dead. That fallback is the only path
 //! that lands a game *patch*, which is why base games installed from the
-//! web UI and updates did not (issue #295).
+//! web UI and updates did not (the web UI half of #152).
 //!
 //! Two sources, in this order:
 //!

--- a/engine/crates/ps5upload-engine/src/lib.rs
+++ b/engine/crates/ps5upload-engine/src/lib.rs
@@ -8298,7 +8298,7 @@ async fn debug_crash(Query(q): Query<DebugCrashQuery>) -> axum::response::Respon
 /// Exists so the self-hosted web UI can light up the same connection
 /// status dots the desktop client does. A browser cannot open a raw
 /// socket, so without this the Connection screen and the first-run
-/// reachability step were both dead in a browser session (#295).
+/// reachability step were both dead in a browser session (#300).
 ///
 /// Mirrors the `port_check` Tauri command's shape exactly —
 /// `{ open: bool, error: string|null }` — so the two transports stay

--- a/engine/crates/ps5upload-engine/src/pkg_install.rs
+++ b/engine/crates/ps5upload-engine/src/pkg_install.rs
@@ -171,7 +171,7 @@ pub fn router(state: PkgInstallStateHandle) -> Router {
         // helper back afterwards. The desktop client does both itself from
         // its own embedded ELFs; a browser can do neither, which left the
         // web UI with no DPI fallback at all — so no way to install a game
-        // patch (issue #295). See `bundled_payload`.
+        // patch (the web UI half of #152). See `bundled_payload`.
         .route("/api/pkg/dpi-ensure", post(dpi_ensure_handler))
         .route("/api/pkg/payload-restore", post(payload_restore_handler))
         // Direct/streaming install (beta, #81): skip the staging upload


### PR DESCRIPTION
`#295` is a dependabot PR bumping `smb2` — completely unrelated. It had been used as the anchor for the web UI update-install work across 19 comments, in v5.16.0 and again in #300, sending anyone who followed the reference to the wrong place.

That work has no issue of its own — it came from a community report against the **#152** fix ("I can confirm that the fix works on the windows app with package install … but the same issue still persists when i try to use the webui upload menu"). So #152 is the correct anchor for the update-install behaviour, and #300 for the browser/engine parity work it grew into.

Comments and one workflow header only — no behaviour change. Gates re-run: `cargo fmt --check`, client typecheck, eslint, 113 files / 1197 tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ao1RVsoPJp4hQywWgq3bJr