### PR TITLE
fix(engine,payload): stop refusing uploads that fit on internal storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ What's new in ps5upload, written for humans.
 
 ---
 
+## 5.17.1
+
+**Uploads to internal storage are no longer refused when there is plenty of room.**
+
+- **The "not enough space" rejection was wrong.** 5.17.0 added a capacity check
+  that held back a flat 80 GB on the PS5's internal storage before deciding
+  whether an upload would fit. That figure came from one console where the PS5
+  really did stop accepting writes with ~86 GB still showing free, and it does
+  not carry over to other consoles: the gap it was modelling turned out to be
+  anywhere from nothing at all to about 58 GB. The result was a check that
+  refused transfers with obvious room for them — a 2.5 GB update onto a console
+  reporting 86 GB free, a 70 GB game onto one reporting 136 GB. If your Volumes
+  screen showed a large "reserved for system" figure and almost nothing
+  available, that was this.
+
+  The check now holds back only a small filesystem working margin, so it stops
+  a transfer only when the space genuinely is not there. A console that
+  overstates its own free space is still caught — but while writing, where
+  ps5upload already turns it into a plain explanation of what happened instead
+  of a bare connection error, rather than up front on a guess.
+
+  If you update the app but keep an older helper on the console, you are not
+  stuck: the app now ignores the old 80 GB figure when the helper reports it.
+
+---
+
 ## 5.17.0
 
 **The self-hosted web UI catches up with the desktop app.**

--- a/engine/crates/ps5upload-core/src/transfer.rs
+++ b/engine/crates/ps5upload-core/src/transfer.rs
@@ -2408,7 +2408,11 @@ const CAPACITY_EXHAUSTED_FLOOR: u64 = 1024 * 1024 * 1024;
 /// Telemetry failure returns `None` — a busy management port must never
 /// invent a disk-full verdict.
 fn capacity_exhausted_body(volume: &crate::volumes::Volume) -> Option<String> {
-    let allocatable = volume.allocatable_bytes();
+    // Diagnosis, not gating, so this may use the pessimistic hidden-pool
+    // estimate that `allocatable_bytes()` deliberately does not. Being wrong
+    // here costs a mis-worded error on a transfer that already failed; being
+    // wrong in the gate costs the user the transfer itself.
+    let allocatable = volume.diagnostic_allocatable_bytes();
     if allocatable >= CAPACITY_EXHAUSTED_FLOOR {
         return None;
     }
@@ -2418,14 +2422,11 @@ fn capacity_exhausted_body(volume: &crate::volumes::Volume) -> Option<String> {
     // message back into the raw socket error it exists to replace.
     let detail = format!(
         "The PS5 ran out of usable space on {} while writing, so it closed the connection. \
-         {} reports {} bytes free, but {} bytes are held back by the console for system and \
-         filesystem overhead, leaving {} actually allocatable. Free up space on the PS5 (or \
-         pick another drive) and start the upload again — retrying now cannot succeed.",
-        volume.path,
-        volume.path,
-        volume.free_bytes,
-        volume.safety_reserve_bytes(),
-        allocatable,
+         {} reports {} bytes free, but the console holds back a large pool for its own \
+         content allocator that this figure never reflects, leaving roughly {} bytes \
+         actually usable. Free up space on the PS5 (or pick another drive) and start the \
+         upload again — retrying now cannot succeed.",
+        volume.path, volume.path, volume.free_bytes, allocatable,
     );
     Some(serde_json::json!({ "error": "insufficient_space", "detail": detail }).to_string())
 }
@@ -5687,7 +5688,7 @@ mod retry_classification_tests {
 
     #[test]
     fn out_of_space_is_reported_instead_of_a_bare_socket_error() {
-        use crate::volumes::{Volume, INTERNAL_STORAGE_SAFETY_RESERVE_BYTES};
+        use crate::volumes::{Volume, INTERNAL_STORAGE_HIDDEN_RESERVE_ESTIMATE_BYTES};
         let full = Volume {
             path: "/data".into(),
             mount_from: "/user/data".into(),
@@ -5729,7 +5730,7 @@ mod retry_classification_tests {
             ..full.clone()
         };
         assert!(
-            roomy.allocatable_bytes() > INTERNAL_STORAGE_SAFETY_RESERVE_BYTES,
+            roomy.diagnostic_allocatable_bytes() > INTERNAL_STORAGE_HIDDEN_RESERVE_ESTIMATE_BYTES,
             "sanity: this volume really does have room"
         );
         assert!(

--- a/engine/crates/ps5upload-core/src/volumes.rs
+++ b/engine/crates/ps5upload-core/src/volumes.rs
@@ -16,12 +16,20 @@ use serde::{Deserialize, Serialize};
 
 use crate::connection::Connection;
 
-/// The PS5 content-storage allocator keeps an internal pool that is not
-/// reflected reliably by `statfs(2)` on `/data`/`/user`. Real-world captures
-/// show allocation failing with ENOSPC while `f_bavail` still reports roughly
-/// 70 GB. Keep an additional 80 GiB out of upload capacity so a large transfer
-/// is rejected before it spends hours reaching that allocator boundary.
-pub const INTERNAL_STORAGE_SAFETY_RESERVE_BYTES: u64 = 80 * 1024 * 1024 * 1024;
+/// Rough size of the PS5 content allocator's hidden pool — capacity that
+/// `statfs(2)` on `/data`/`/user` advertises but the console will not actually
+/// hand out. A FW 12.00 capture hit ENOSPC with ~86 GB still showing free.
+///
+/// **This is an estimate for explaining a failure, never for preventing one.**
+/// It is deliberately NOT part of `safety_reserve_bytes()`. Subtracting it up
+/// front looked reasonable with n=1 and was badly wrong in the field: the gap
+/// is not a constant. Two later consoles measured 0 GB and ~58 GB against this
+/// 80 GiB, so as a gate it refused transfers that fit easily — a 2.5 GiB pkg
+/// onto a console with 86 GB free, and 70 GB onto one with 136 GB free.
+///
+/// Used only by the post-drop diagnosis, which runs after a transfer has
+/// already failed and only decides how to word the error.
+pub const INTERNAL_STORAGE_HIDDEN_RESERVE_ESTIMATE_BYTES: u64 = 80 * 1024 * 1024 * 1024;
 
 /// Leave a small working margin on ordinary external filesystems for metadata,
 /// journals, and activity elsewhere on the drive during a long upload. This is
@@ -98,17 +106,38 @@ impl Volume {
         self.path == "/data" || self.path == "/user" || self.mount_from.contains("ssd0.user")
     }
 
+    /// Capacity held back from the *blocking* capacity gate.
+    ///
+    /// This is a small filesystem working margin and nothing more. It must
+    /// stay small: the gate it feeds refuses the transfer outright, so
+    /// anything speculative here becomes a transfer the user cannot make at
+    /// all. The console's hidden content-allocator pool is explicitly NOT
+    /// modelled here — see `INTERNAL_STORAGE_HIDDEN_RESERVE_ESTIMATE_BYTES`
+    /// for why guessing at it up front was a mistake.
     pub fn safety_reserve_bytes(&self) -> u64 {
-        if self.safety_reserve_bytes > 0 {
-            self.safety_reserve_bytes
-        } else if self.is_internal_user_storage() {
-            // Deliberately NOT scaled. This models the PS5 content
-            // allocator's hidden reserve, an absolute quantity — a FW 12.00
-            // capture predicted that console's real usable space to within
-            // 0.06 GB of 153 GB with this exact constant.
-            INTERNAL_STORAGE_SAFETY_RESERVE_BYTES
+        let local = external_reserve_for_total(self.total_bytes);
+        if self.safety_reserve_bytes == 0 {
+            return local;
+        }
+        if self.is_internal_user_storage() {
+            // Payloads at 5.17.0 and earlier publish a flat 80 GiB here. A
+            // user who updates the app but keeps an old payload on the
+            // console would otherwise stay blocked by the very bug this
+            // fixes, so an internal volume's published reserve is capped at
+            // what we would compute ourselves.
+            return self.safety_reserve_bytes.min(local);
+        }
+        self.safety_reserve_bytes
+    }
+
+    /// Free space adjusted by the *estimated* hidden allocator pool, for
+    /// diagnosis only. Never use this to decide whether to start a transfer.
+    pub fn diagnostic_allocatable_bytes(&self) -> u64 {
+        if self.is_internal_user_storage() {
+            self.free_bytes
+                .saturating_sub(INTERNAL_STORAGE_HIDDEN_RESERVE_ESTIMATE_BYTES)
         } else {
-            external_reserve_for_total(self.total_bytes)
+            self.allocatable_bytes()
         }
     }
 
@@ -116,10 +145,15 @@ impl Volume {
         // A legitimate new-payload response may publish zero when the drive is
         // inside its safety reserve, so only trust the wire value when nonzero.
         // Recomputing is equivalent in the zero case and handles old payloads.
+        // Never trust a published value that is smaller than our own rule
+        // would give: an old payload's flat 80 GiB internal reserve arrives
+        // here pre-applied, and honouring it would reinstate the block that
+        // `safety_reserve_bytes` above exists to lift.
+        let local = self.free_bytes.saturating_sub(self.safety_reserve_bytes());
         if self.allocatable_bytes > 0 {
-            self.allocatable_bytes.min(self.free_bytes)
+            self.allocatable_bytes.min(self.free_bytes).max(local)
         } else {
-            self.free_bytes.saturating_sub(self.safety_reserve_bytes())
+            local
         }
     }
 }
@@ -310,15 +344,16 @@ mod tests {
             EXTERNAL_STORAGE_SAFETY_RESERVE_BYTES
         );
 
-        // Internal storage must NOT scale — the 80 GiB models the PS5
-        // content allocator and was validated against a live FW 12.00 capture.
+        // Internal storage gets the same small working margin as anything
+        // else. It used to get a flat 80 GiB, which is what made the console
+        // in `internal_gate_does_not_block_transfers_that_fit` unusable.
         let internal: Volume = serde_json::from_str(
             r#"{"path":"/data","mount_from":"/user/data","fs_type":"nullfs","total_bytes":673865203712,"free_bytes":609649819648,"writable":true}"#,
         )
         .unwrap();
         assert_eq!(
             internal.safety_reserve_bytes(),
-            INTERNAL_STORAGE_SAFETY_RESERVE_BYTES
+            EXTERNAL_STORAGE_SAFETY_RESERVE_BYTES
         );
 
         // Unknown total reserves nothing rather than blocking everything.
@@ -333,7 +368,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             internal.allocatable_bytes(),
-            150_000_000_000 - INTERNAL_STORAGE_SAFETY_RESERVE_BYTES
+            150_000_000_000 - EXTERNAL_STORAGE_SAFETY_RESERVE_BYTES
         );
 
         let external: Volume = serde_json::from_str(
@@ -342,6 +377,72 @@ mod tests {
         .unwrap();
         assert_eq!(external.safety_reserve_bytes(), 2 * 1024 * 1024 * 1024);
         assert_eq!(external.allocatable_bytes(), 897_852_516_352);
+    }
+
+    /// Both numbers here are verbatim from user bug reports against 5.17.0.
+    /// Each was refused by the flat 80 GiB internal reserve while the console
+    /// plainly had room, which is the whole reason that reserve is gone.
+    #[test]
+    fn internal_gate_does_not_block_transfers_that_fit() {
+        // Report 1 (FW 11.00). Payload log: free=86285615104 reserve=85899345920
+        // -> 386269184 allocatable, so a 2.5 GB pkg was rejected outright.
+        let user: Volume = serde_json::from_str(
+            r#"{"path":"/user","mount_from":"/dev/ssd0.user","fs_type":"ufs","total_bytes":904129740800,"free_bytes":86285615104,"writable":true}"#,
+        )
+        .unwrap();
+        assert!(
+            user.allocatable_bytes() >= 2_498_035_712,
+            "a 2.5 GB pkg must fit in 86 GB of free space, got {} allocatable",
+            user.allocatable_bytes()
+        );
+
+        // Report 2: BeginTx rejected a 70 GB game with 136 GB free.
+        let data: Volume = serde_json::from_str(
+            r#"{"path":"/data","mount_from":"/user/data","fs_type":"nullfs","total_bytes":904129740800,"free_bytes":136368816128,"writable":true}"#,
+        )
+        .unwrap();
+        assert!(
+            data.allocatable_bytes() >= 70_490_481_725,
+            "a 70 GB game must fit in 136 GB of free space, got {} allocatable",
+            data.allocatable_bytes()
+        );
+    }
+
+    /// A console still running a 5.17.0-era payload publishes the old flat
+    /// reserve on the wire. Updating only the app must still fix the user.
+    #[test]
+    fn stale_payload_reserve_does_not_reinstate_the_block() {
+        let stale: Volume = serde_json::from_str(
+            r#"{"path":"/user","mount_from":"/dev/ssd0.user","fs_type":"ufs","total_bytes":904129740800,"free_bytes":86285615104,"writable":true,"safety_reserve_bytes":85899345920,"allocatable_bytes":386269184}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            stale.safety_reserve_bytes(),
+            EXTERNAL_STORAGE_SAFETY_RESERVE_BYTES
+        );
+        assert!(
+            stale.allocatable_bytes() >= 2_498_035_712,
+            "got {} allocatable",
+            stale.allocatable_bytes()
+        );
+    }
+
+    /// The estimate survives, but only where it cannot block anything.
+    #[test]
+    fn hidden_reserve_estimate_is_diagnosis_only() {
+        let full: Volume = serde_json::from_str(
+            r#"{"path":"/data","mount_from":"/user/data","fs_type":"nullfs","total_bytes":947229556736,"free_bytes":85962588160,"writable":true}"#,
+        )
+        .unwrap();
+        assert!(
+            full.diagnostic_allocatable_bytes() < 1024 * 1024 * 1024,
+            "the FW 12.00 console must still be diagnosable as full"
+        );
+        assert_eq!(
+            full.allocatable_bytes(),
+            85_962_588_160 - EXTERNAL_STORAGE_SAFETY_RESERVE_BYTES,
+            "but it must not be blocked up front"
+        );
     }
 
     #[test]

--- a/payload/src/runtime.c
+++ b/payload/src/runtime.c
@@ -78,12 +78,13 @@ extern int posix_fadvise(int fd, off_t offset, off_t len, int advice);
  * with the data-write loop on multi-GiB copies. */
 extern int posix_fallocate(int fd, off_t offset, off_t len);
 
-/* Capacity policy mirrored by ps5upload-core::volumes. The PS5 user-storage
- * allocator can return ENOSPC while statfs(/data) still advertises roughly
- * 70 GB. Keep 80 GiB out of large uploads on internal storage, plus 1 GiB on
- * ordinary external/image filesystems for metadata and concurrent activity. */
+/* Capacity policy mirrored by ps5upload-core::volumes. Keep a small working
+ * margin -- 1 GiB, scaled down for small volumes -- out of every filesystem
+ * for metadata and concurrent activity. The PS5 user-storage allocator can
+ * still return ENOSPC while statfs(/data) advertises far more; that is not
+ * predictable here and is handled after the fact, not by this gate. See
+ * capacity_reserve_for_mount. */
 #define PS5UPLOAD2_GIB ((uint64_t)1024u * 1024u * 1024u)
-#define PS5UPLOAD2_INTERNAL_SPACE_RESERVE (80u * PS5UPLOAD2_GIB)
 #define PS5UPLOAD2_EXTERNAL_SPACE_RESERVE (1u * PS5UPLOAD2_GIB)
 
 #define FTX2_MAGIC 0x32585446u
@@ -5649,22 +5650,27 @@ static int is_user_storage_path(const char *path) {
  * external_reserve_for_total}. The host falls back to the SAME rule when an
  * older payload omits the published field, so the two must not drift.
  *
- * The external margin is a CAP scaled to the volume, not a flat charge: a
- * flat 1 GiB on a 64 MiB mounted disk image reserves sixteen times its own
- * capacity, drives allocatable to zero, and refuses every write to it
+ * The margin is a CAP scaled to the volume, not a flat charge: a flat 1 GiB
+ * on a 64 MiB mounted disk image reserves sixteen times its own capacity,
+ * drives allocatable to zero, and refuses every write to it
  * (hardware-confirmed — a 29-byte write into a mounted 64 MiB image was
- * rejected as "have 0 bytes"). The INTERNAL reserve is deliberately NOT
- * scaled: it models the PS5 content allocator's hidden reserve, an absolute
- * quantity validated against a live FW 12.00 capture. */
+ * rejected as "have 0 bytes"). Internal storage is no longer a special case;
+ * the body says why. */
 static uint64_t capacity_reserve_for_mount(const char *mnt_on,
                                            const char *mnt_from,
                                            uint64_t total_bytes) {
     uint64_t scaled;
-    if ((mnt_on && (strcmp(mnt_on, "/data") == 0 ||
-                    strcmp(mnt_on, "/user") == 0)) ||
-        (mnt_from && strstr(mnt_from, "ssd0.user") != NULL)) {
-        return PS5UPLOAD2_INTERNAL_SPACE_RESERVE;
-    }
+    /* Internal storage (/data, /user) used to get a flat 80 GiB here, meant
+     * to model the PS5 content allocator's hidden pool. It was fitted to one
+     * FW 12.00 capture and did not generalise: this gate then rejected a
+     * 2.5 GiB pkg on a console with 86 GB free, and a 70 GB game on one with
+     * 136 GB free. The pool is real, but its size is not predictable from
+     * anything readable here -- and this gate REFUSES the transfer, so it now
+     * blocks only what is certainly impossible. A console that overstates its
+     * free space is caught mid-write instead, where the host turns that into
+     * a plain-language error (ps5upload-core::transfer::capacity_exhausted_body). */
+    (void)mnt_on;
+    (void)mnt_from;
     /* A volume reporting no total reserves nothing — better to let the write
      * be attempted than to block it on missing telemetry. */
     scaled = total_bytes / 64u;


### PR DESCRIPTION
## The bug

5.17.0 added a capacity gate that holds back a **flat 80 GiB** on `/data` and `/user` before deciding whether an upload fits. Two field reports:

```
capacity reject tx a5d8… free=86285615104 reserve=85899345920
  -> 386,269,184 allocatable   (2.5 GB pkg refused, 86 GB free)

BeginTx rejected: needs 70490481725 bytes, 136368816128 free
```

That 368 MiB is the user-visible *"only 300mb available and 80gb reserved for system"*.

The constant came from `bf9c5b51`, fitted to **one** FW 12.00 capture where a console really did stop accepting writes with ~86 GB showing free. Generalising that gap to a universal constant was the mistake — measured against the two consoles above it is ~0 GB and ~58 GB. It was never a constant.

## The fix

A gate that **refuses** a transfer may only encode what is *certainly impossible*. A false reject costs the user the transfer outright; a false accept costs an upload that fails partway — which `capacity_exhausted_body` already turns into a plain-language error rather than a bare socket failure.

So the 80 GiB estimate moves to `diagnostic_allocatable_bytes()`, used only by the post-drop diagnosis where being wrong just changes wording. The blocking gate keeps the same small margin as any other filesystem. Mirrored in the payload, whose `BEGIN_TX` gate is what actually rejected both reports.

Old payloads publish the stale reserve on the wire, so an internal volume's published value is now capped at what the host computes itself — **updating the app alone unblocks a user**, no payload redeploy needed.

## Verification

Hardware, both consoles, fixed payload deployed:

| | reserve | allocatable before | after |
|---|---|---|---|
| Pro (FW 9.60) | 80 GiB → **1.07 GB** | 81.0 GB | **165.8 GB** |
| Phat (FW 5.10) | 80 GiB → **1.07 GB** | 513.6 GB | **598.5 GB** |

Transfers of 1 MB, 8.69 GB and 26.37 GB all committed byte-exact (the largest at ~95 MB/s), then installed. 3 regression tests use the reporters' exact byte counts. `cargo test -p ps5upload-core` 432 passed, `make test-payload` green, `npm run validate` green.

## Not covered by this PR

Hardware testing raised two further items. **Both of my original descriptions of them were wrong and are corrected here.**

- **PS4 patch install — inconclusive, one real failure.** A Bloodborne `A0109` patch (`app_ver 01.09`, `gp`/PS4DP) over an installed `01.00`:
  - **Pro (FW 9.60, game on M.2): applied.** `01.00` → `01.09`, size +8.69 GB, 52 seconds after the call.
  - **Phat (FW 5.10, game on internal): no change after >1 hour.**

  I first reported this as "reproduced on both firmwares, therefore package-type-specific". That was wrong — I checked `APP_VER` ~30 s and ~50 s after the call, inside the window the Pro needed to update. PS4 installs are asynchronous; the correct method is to poll for minutes. Firmware and storage location remain confounded (the Phat has no M.2, so the game cannot be relocated to separate them).

- **"Stream install kills the payload" — retracted, my error.** It was caused by calling `/api/pkg/install/start` with a PC `path` but without `serve_only: true`, which routes into the in-process `InstallByPackage` with an `http://` URL — a hazard FW < 11 documents in this repo and which the `serve_only` branch exists to avoid. The shipping client always sends `serveOnly: true`. Re-run correctly, the payload stayed up.

Neither is affected by this PR: a gate that only rejects cannot break an install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JgHga57CjHNx8xvZYzLB1R
