### PR TITLE
fix(engine,client): log levels that mean something, bug reports that explain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ What's new in ps5upload, written for humans.
 
 ---
 
+## 5.17.2
+
+**Logs say what they mean, and a bug report now carries what we actually need.**
+
+- **The engine log no longer labels everything an error.** The engine writes
+  all of its output — routine, warning, failure alike — down one pipe, and the
+  app was stamping that whole pipe as an error. A perfectly healthy session read
+  as a wall of `[engine:err] ... 200 (0ms)` lines, every one of which was a
+  success. Lines that already state their own level are now left alone. The Logs
+  screen in the app was always right about this; it was the log file inside a bug
+  report — the one a maintainer reads — that was wrong.
+
+- **The log stopped filling up with itself.** The Logs screen asks the engine for
+  new lines about once a second, and each of those requests was being written to
+  the log. Watching the log made it grow, forever, burying real activity. Reading
+  the log is no longer an event.
+
+- **Failures are recorded as failures.** Nothing in the engine had ever been
+  logged at error level, so every bug report said "0 errors" no matter what had
+  gone wrong, and filtering for errors showed an empty list. A transfer that dies
+  and an install the console refuses are now errors. Advisories that cost you
+  nothing stay warnings.
+
+- **Bug reports capture more of what a report is usually about.** Newly included:
+  free space per drive *with the reserved amount* (a 5.17.0 report about missing
+  space needed a hand-grep through helper logs to explain — that is now visible
+  at a glance), the list of installed titles, why each transfer ended rather than
+  just that it did, and what the console reported about an install. Package
+  filenames are included; the folders they came from are not.
+
+---
+
 ## 5.17.1
 
 **Uploads to internal storage are no longer refused when there is plenty of room.**

--- a/client/src-tauri/src/commands/bug_report.rs
+++ b/client/src-tauri/src/commands/bug_report.rs
@@ -280,7 +280,10 @@ diagnostics to help debug an issue — no games or app data.\n\
 \n\
   report.json          Summary: app version, OS, your description, the\n\
                        selected log level/window, the diagnostic bundle,\n\
-                       and a snapshot of the connected PS5 (if any).\n\
+                       engine state (transfer jobs with why they failed, and\n\
+                       live install sessions), and a snapshot of the connected\n\
+                       PS5 (if any) — including per-volume free space with the\n\
+                       safety reserve, and the installed title list.\n\
   logs/app.jsonl       The app's unified log for the selected time window\n\
                        (one JSON object per line: ts, level, source, message).\n\
   logs/engine.log      Full transfer-engine log (crash-survivable).\n\

--- a/client/src-tauri/src/engine.rs
+++ b/client/src-tauri/src/engine.rs
@@ -706,6 +706,14 @@ pub async fn stop() {
 /// Per-line write so log rotation later can split on newlines without
 /// risking torn lines mid-write. The Mutex is std (not tokio) because
 /// the critical section is a sync `write_all` + flush — no awaits.
+/// True when a line the engine emitted already states its own level, e.g.
+/// `[engine:debug] ...`. Such a line must not be re-tagged by the pipe it
+/// happened to arrive on — the engine sends every level to stderr, so the
+/// pipe says nothing about severity.
+fn line_is_pre_tagged(line: &str) -> bool {
+    line.trim_start().starts_with("[engine")
+}
+
 async fn pipe_tagged<R>(mut reader: R, tag: &'static str, log: Option<Arc<Mutex<std::fs::File>>>)
 where
     R: tokio::io::AsyncRead + Unpin + Send + 'static,
@@ -721,10 +729,28 @@ where
     let mut line: Vec<u8> = Vec::with_capacity(256);
     let emit_bytes = |bytes: &[u8]| {
         let s = String::from_utf8_lossy(bytes);
-        eprintln!("{tag}{s}");
+        // The engine writes ALL of its own logs to stderr, each already
+        // carrying its real level (`[engine:debug]`, `[engine:info]`, ...).
+        // Blanket-prefixing the stderr pipe with `[engine:err] ` therefore
+        // relabelled every successful debug line as an error: a healthy
+        // session reads as a wall of `[engine:err] ... -> 200 (0ms)`, which
+        // is alarming and hides the failures that matter. A line that
+        // already states its level is passed through untouched; only
+        // genuinely untagged output (a panic, a linker message) still gets
+        // the pipe's tag, which is exactly the case the tag is for.
+        let pre_tagged = line_is_pre_tagged(&s);
+        if pre_tagged {
+            eprintln!("{s}");
+        } else {
+            eprintln!("{tag}{s}");
+        }
         if let Some(writer) = &log {
             if let Ok(mut f) = writer.lock() {
-                let _ = writeln!(f, "{tag}{s}");
+                let _ = if pre_tagged {
+                    writeln!(f, "{s}")
+                } else {
+                    writeln!(f, "{tag}{s}")
+                };
                 let _ = f.flush();
             }
         }
@@ -822,4 +848,37 @@ fn is_loopback_url(url: &str) -> bool {
             .parse::<std::net::IpAddr>()
             .map(|ip| ip.is_loopback())
             .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod log_tag_tests {
+    use super::line_is_pre_tagged;
+
+    #[test]
+    fn engine_own_levels_are_not_relabelled_as_errors() {
+        // Straight from a user report: a healthy session showed hundreds of
+        // `[engine:err] [engine:debug] ... -> 200 (0ms)` lines. Every one was
+        // a success logged at debug, mislabelled because it arrived on stderr.
+        for line in [
+            "[engine:debug] ts=1788748874711 GET /api/engine-logs -> 200 (0ms)",
+            "[engine:info] fs_delete ok: /data/ps5upload in 359 ms",
+            "[engine:warn] GET /api/ps5/status -> 502 (2576ms)",
+            "  [engine:debug] leading whitespace still counts",
+        ] {
+            assert!(line_is_pre_tagged(line), "must pass through: {line}");
+        }
+    }
+
+    #[test]
+    fn untagged_output_still_gets_the_pipe_tag() {
+        // Panics and linker noise carry no level of their own, which is the
+        // case the pipe tag exists for.
+        for line in [
+            "thread 'main' panicked at src/lib.rs:1:1",
+            "",
+            "Segmentation fault",
+        ] {
+            assert!(!line_is_pre_tagged(line), "must be tagged: {line}");
+        }
+    }
 }

--- a/client/src/lib/engineDiagnostics.ts
+++ b/client/src/lib/engineDiagnostics.ts
@@ -1,0 +1,64 @@
+import { getEngineUrl } from "../state/engine";
+
+/**
+ * Host-side (engine) state for the bug-report bundle.
+ *
+ * These are NOT PS5 probes — they read the engine's own in-memory state over
+ * loopback and answer immediately, so they are safe to collect even when the
+ * console is off. They cover the two questions a transfer/install report
+ * always raises and that the bundle previously could not answer:
+ *
+ *  - `jobs`     — why a transfer ended, with the structured `error_reason` /
+ *                 `error_detail` the UI shows. The bundle used to carry only
+ *                 the renderer's `recent_activity` labels ("Installing X",
+ *                 outcome "failed"), which name the failure but never explain
+ *                 it.
+ *  - `sessions` — what the console said about an install. `install/status`
+ *                 requires a session id, so once the user navigated away the
+ *                 err_code and phase were unrecoverable.
+ */
+
+/** Per-request budget. The engine is loopback and answers from memory; a
+ *  wedged accept loop must not hang bundle generation, which is the one
+ *  action a user takes precisely because things are already broken. */
+const TIMEOUT_MS = 2000;
+
+async function getJsonBounded<T>(path: string): Promise<T> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(`${getEngineUrl()}${path}`, {
+      signal: controller.signal,
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return (await res.json()) as T;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export interface EngineDiagnostics {
+  /** Transfer jobs the engine still holds, newest state included. */
+  jobs: unknown[] | null;
+  /** Live pkg-install sessions. */
+  install_sessions: unknown[] | null;
+  /** Per-probe failures, so "not collected" is never read as "nothing there". */
+  errors: Record<string, string>;
+}
+
+export async function collectEngineDiagnostics(): Promise<EngineDiagnostics> {
+  const errors: Record<string, string> = {};
+  async function probe<T>(name: string, path: string): Promise<T | null> {
+    try {
+      return await getJsonBounded<T>(path);
+    } catch (e) {
+      errors[name] = e instanceof Error ? e.message : String(e);
+      return null;
+    }
+  }
+  const [jobs, sessions] = await Promise.all([
+    probe<unknown[]>("jobs", "/api/jobs"),
+    probe<unknown[]>("install_sessions", "/api/pkg/install/sessions"),
+  ]);
+  return { jobs, install_sessions: sessions, errors };
+}

--- a/client/src/lib/ps5Snapshot.ts
+++ b/client/src/lib/ps5Snapshot.ts
@@ -9,6 +9,8 @@ import {
   fetchHwPower,
   fetchHwStorage,
   appListRunning,
+  appsInstalled,
+  listVolumes,
   procListGet,
   netInterfacesGet,
   klogChunk,
@@ -25,6 +27,7 @@ import {
   type RunningApp,
   type ProcEntry,
   type NetInterface,
+  type Volume,
 } from "../api/ps5";
 
 /**
@@ -64,6 +67,17 @@ export interface Ps5Snapshot {
   processes: ProcEntry[] | null;
   processes_total: number | null;
   net_interfaces: NetInterface[] | null;
+  /** Per-mount capacity, INCLUDING `safety_reserve_bytes` /
+   *  `allocatable_bytes`. `hw_storage` only carries the console-wide
+   *  aggregate, which cannot show why an upload was refused. A 5.17.0 report
+   *  ("only 300mb available, 80gb reserved") took a payload-log grep to
+   *  diagnose because this was missing; with it the cause is one glance. */
+  volumes: Volume[] | null;
+  /** Registered title ids. `running_apps` covers what is running; this covers
+   *  what is INSTALLED, which is what "the game shows a broken tile" and
+   *  "my update did not apply" reports actually turn on. */
+  installed_apps: { title_id: string; title_name?: string }[] | null;
+  installed_apps_total: number | null;
   /** ShadowMount+ state. It owns mounting and registration for disk images,
    *  so whether it is running (and what it has mounted) explains a whole
    *  class of "my game didn't appear" reports our own logs cannot. */
@@ -108,6 +122,9 @@ export interface Ps5SnapshotResult {
 /** Cap the embedded process list so a busy console can't bloat report.json;
  *  the full count is preserved in `processes_total`. */
 const PROC_CAP = 400;
+/** Installed-title cap. A full console runs to a few hundred titles; the ids
+ *  matter, the tail does not, and the bundle is posted to a chat channel. */
+const INSTALLED_APP_CAP = 500;
 
 function placeholder(v: string | null | undefined): string | null {
   if (!v) return v ?? null;
@@ -216,6 +233,9 @@ export async function buildPs5Snapshot(opts: {
     processes: null,
     processes_total: null,
     net_interfaces: null,
+    volumes: null,
+    installed_apps: null,
+    installed_apps_total: null,
     smp_status: null,
     smp_checkout: null,
     focus: null,
@@ -252,6 +272,8 @@ export async function buildPs5Snapshot(opts: {
     apps,
     procs,
     nets,
+    volumes,
+    installedApps,
     smp,
     checkout,
     focus,
@@ -268,6 +290,8 @@ export async function buildPs5Snapshot(opts: {
       probe("running_apps", () => appListRunning(maddr)),
       probe("processes", () => procListGet(maddr)),
       probe("net_interfaces", () => netInterfacesGet(maddr)),
+      probe("volumes", () => listVolumes(taddr)),
+      probe("installed_apps", () => appsInstalled(taddr)),
       probe("smp_status", () => smpStatus(taddr)),
       probe("smp_checkout", () => smpCheckoutStatus(taddr)),
       // Newer helpers only; an older payload rejects the frame and this
@@ -296,6 +320,15 @@ export async function buildPs5Snapshot(opts: {
   }
 
   base.net_interfaces = nets?.interfaces ?? null;
+  base.volumes = volumes;
+  if (installedApps?.titles) {
+    base.installed_apps_total = installedApps.titles.length;
+    // Ids + names only: origin/source add bulk without changing a diagnosis,
+    // and the list is capped for the same reason `processes` is.
+    base.installed_apps = installedApps.titles
+      .slice(0, INSTALLED_APP_CAP)
+      .map((t) => ({ title_id: t.titleId, title_name: t.titleName }));
+  }
   base.smp_status = smp;
   base.smp_checkout = checkout;
   base.focus = focus;

--- a/client/src/screens/BugReport/index.tsx
+++ b/client/src/screens/BugReport/index.tsx
@@ -27,6 +27,7 @@ import { useTr } from "../../state/lang";
 import { useDiagSettingsStore, LOG_LEVELS } from "../../state/diagSettings";
 import { useConnectionStore } from "../../state/connection";
 import { buildDiagnosticBundle } from "../../lib/diagnosticBundle";
+import { collectEngineDiagnostics } from "../../lib/engineDiagnostics";
 import { buildPs5Snapshot } from "../../lib/ps5Snapshot";
 import { ensurePayloadCurrent } from "../../lib/ensurePayloadCurrent";
 import { hostOf } from "../../lib/addr";
@@ -236,6 +237,10 @@ export default function BugReportScreen() {
         payload_logs: payloadLogs,
       } = await buildPs5Snapshot({ redact });
 
+      // Engine-side state (loopback, in-memory): why transfers ended and what
+      // the console said about installs. Collected even when the PS5 is off.
+      const engineDiag = await collectEngineDiagnostics();
+
       const manifest = {
         schema: 1,
         kind: "ps5upload-bug-report",
@@ -251,6 +256,7 @@ export default function BugReportScreen() {
         redacted: redact,
         includes: include,
         diagnostic: bundle,
+        engine: engineDiag,
         ps5: snapshot,
       };
 

--- a/engine/crates/ps5upload-engine/src/lib.rs
+++ b/engine/crates/ps5upload-engine/src/lib.rs
@@ -318,7 +318,14 @@ fn job_failed_from_err(started_at_ms: u64, completed_at_ms: u64, err: &anyhow::E
     // reconcile, download). Logging here means a mid-transfer death — the
     // "upload failed halfway through" case — shows the engine's full error
     // chain in engine.log, instead of the handler logging only the START.
-    log_warn!(
+    //
+    // `error`, not `warn`: the user's transfer is over and did not succeed.
+    // The engine used to have no `error` call sites at all, so every bug
+    // bundle reported `error_logs: 0` however badly a transfer had failed,
+    // and a maintainer filtering for errors saw an empty list. Advisory
+    // warnings ("capacity preflight unavailable", which only skips a check)
+    // stay at `warn` — the distinction is whether the user lost work.
+    log_error!(
         "transfer job failed: {err:#}{}",
         reason
             .as_deref()
@@ -476,7 +483,16 @@ async fn log_requests(req: Request, next: Next) -> axum::response::Response {
     // The full per-request trace always goes to the debug log, which is
     // what the crash trace relies on. What varies is whether this also
     // reaches the user at the default level.
-    log_debug!("{method} {path} -> {status} ({ms}ms)");
+    //
+    // The log-tail endpoint is the one exception: the log viewer polls it
+    // about once a second, so logging it makes the log grow purely from
+    // being watched — a self-feeding stream of `GET /api/engine-logs -> 200`
+    // that crowds out real traffic and never stops. Reading the log is not
+    // an event worth recording. A failure still gets through: only this
+    // debug line is skipped, and the 5xx path below is untouched.
+    if path != "/api/engine-logs" {
+        log_debug!("{method} {path} -> {status} ({ms}ms)");
+    }
 
     // A console that is switched off answers every status poll with 502,
     // once a second, indefinitely. Reported plainly that buries every

--- a/engine/crates/ps5upload-engine/src/pkg_install.rs
+++ b/engine/crates/ps5upload-engine/src/pkg_install.rs
@@ -160,6 +160,7 @@ pub fn router(state: PkgInstallStateHandle) -> Router {
         .route("/api/ffpkg/extract", post(extract_handler))
         .route("/api/pkg/install/start", post(install_start_handler))
         .route("/api/pkg/install/status", get(install_status_handler))
+        .route("/api/pkg/install/sessions", get(install_sessions_handler))
         .route("/api/pkg/install/cancel", post(install_cancel_handler))
         .route("/api/pkg/installed", get(installed_pkg_inventory_handler))
         // Install a staged .pkg through the standalone DPI daemon (:9040).
@@ -1249,7 +1250,10 @@ async fn install_start_handler(
         // diagnose post-mortem without ssh — the diagnostic disclosure
         // in the UI shows the same fields, but engine.log gives an
         // append-only history per attempt.
-        crate::log_warn!(
+        // `error`: Sony refused the install outright, so the user's package
+        // did not land. Terminal and user-visible — see the note in
+        // `job_failed_from_err` on why this is not a `warn`.
+        crate::log_error!(
             "pkg_install rejected: session={} err_code=0x{:08x} detail={:?} register_path={} intdebug_avail={} kernel_rw={} shellui_err={} appinst_err={}",
             session_id,
             resp.err_code,
@@ -2276,6 +2280,56 @@ pub struct CancelResponse {
     /// BGFT continues running on the PS5; once it sees the HTTP stream
     /// drop it surfaces a download error in PS5 notifications.
     pub host_stopped: bool,
+}
+
+/// GET /api/pkg/install/sessions — summarise every live install session.
+///
+/// Read-only diagnostics. `install/status` needs a session id, so a bug
+/// report could never show what the console said about an install that the
+/// user had already navigated away from — the exact gap that made an
+/// "install reported success but the game is broken" report unanswerable.
+///
+/// Deliberately omits `parts` (host-side absolute paths, which carry the
+/// user's account name) and reports only the file names. Everything else here
+/// is console-side state the bundle already exposes elsewhere.
+async fn install_sessions_handler(State(state): State<PkgInstallStateHandle>) -> Response<Body> {
+    let sessions = state.sessions.lock().unwrap_or_else(|e| e.into_inner());
+    let summary: Vec<serde_json::Value> = sessions
+        .values()
+        .map(|s| {
+            serde_json::json!({
+                "id": s.id,
+                "content_id": s.content_id,
+                "title": s.title,
+                "package_type": s.package_type,
+                "total_size": s.total_size,
+                "part_names": s
+                    .parts
+                    .iter()
+                    .map(|p| {
+                        p.file_name()
+                            .map(|n| n.to_string_lossy().into_owned())
+                            .unwrap_or_default()
+                    })
+                    .collect::<Vec<_>>(),
+                "task_id": s.task_id,
+                "err_code": s.err_code,
+                "detail": s.detail,
+                "cancelled": s.cancelled,
+                "created_at_unix": s.created_at_unix,
+                "staging_path": s.staging_path,
+                "launchable": s.launchable,
+                "serve_only": s.serve_only,
+                "stalled": s.stalled,
+                "accepted_unverified": s.accepted_unverified,
+                "requests_served": s.requests_served,
+                "bytes_served": s.bytes_served,
+                "progress_consumed_bytes": s.progress_consumed_bytes,
+                "last_progress_unix": s.last_progress_unix,
+            })
+        })
+        .collect();
+    json_ok(&summary)
 }
 
 async fn install_cancel_handler(


### PR DESCRIPTION
Prompted by a user pasting their log in alarm. Every visible line was:

```
[engine:err] [engine:debug] ts=... GET /api/engine-logs -> 200 (0ms)
             ^^^^^^^^^^^^^ the real level     ^^^ HTTP 200 = success
```

Not one error in the whole paste. Three separate defects made a healthy session look like a failure flood.

## Logging

**1. Every engine line was relabelled an error.** The engine sends all levels down one pipe (stderr); the desktop shell stamped that whole pipe `[engine:err]`. The in-app Logs screen was never affected — `engineLogBridge` maps levels correctly — so this only ever corrupted **`engine.log`, the file inside a bug bundle**, i.e. the copy a maintainer reads. Lines already carrying their level now pass through; only untagged output (panics, linker noise) still takes the pipe's tag.

**2. The log fed itself.** The Logs screen polls `/api/engine-logs` ~1×/sec and each poll was access-logged, so the log grew from being watched, indefinitely. That loop was **~85% of the reported paste**. Reading the log is no longer an event; the 5xx warn path is untouched.

**3. `log_error!` had zero call sites.** Defined, never called — so every bundle reported `error_logs: 0` no matter what failed, and filtering for errors returned an empty list. A dead transfer (`job_failed_from_err`, the choke point for file/dir/reconcile/download) and a refused install (`pkg_install rejected`) are now errors. Advisories like "capacity preflight unavailable" — which only skips a check — stay warnings. The test applied: **did the user lose work?**

## Bug report capture

The bundle could not answer the questions reports are usually about:

| added | why |
|---|---|
| `volumes` | per-mount free/total **with `safety_reserve_bytes` + `allocatable_bytes`**. `hw_storage` is a console-wide aggregate and cannot show why an upload was refused — diagnosing the 5.17.0 "300mb available, 80gb reserved" report took a grep through payload logs for a single line |
| `installed_apps` | `running_apps` covered what was *running*; nothing covered what was *installed*, which is what "broken tile" and "my update didn't apply" turn on. Capped at 500 |
| `engine.jobs` | why each transfer ended, with `error_reason`/`error_detail`. The bundle carried only renderer labels ("Installing X", outcome "failed") — the failure named, never explained |
| `engine.install_sessions` | new `GET /api/pkg/install/sessions`. `install/status` needs a session id, so once the user navigated away the console's `err_code` and phase were unrecoverable. The `InstallSession` struct already anticipated this endpoint |

**Privacy:** sessions report `part_names` (file names) and never `parts`, whose absolute host paths carry the user's account name. The route is loopback-guarded like every other engine route. Both engine probes are bounded at 2 s so a wedged accept loop cannot hang the one action a user takes *because* things are already broken.

## Verification

Live against the running engine: a created session returned `content_id`, `package_type`, `err_code`, `serve_only`, `requests_served`, `stalled` — with only the pkg file name, no host path. 2 new tag tests, desktop suite 95 passed, client typecheck clean, `diagnosticBundle` 15/15, `npm run validate` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JgHga57CjHNx8xvZYzLB1R