### PR TITLE
build: stop every build from stripping the client lockfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ What's new in ps5upload, written for humans.
 
 ---
 
+## 5.17.6
+
+**A build fix, and one that quietly protected the Docker image.**
+
+- **Building the app no longer damages its own dependency lockfile.** Every
+  build ran `npm install`, which on npm 10 deletes information newer npm
+  versions record — including which native components match Alpine/musl, the
+  base the web UI Docker image is built on. It had to be undone by hand before
+  every release, and had it ever been committed, that image could have been
+  built with the wrong native binaries. Builds now install strictly from the
+  lockfile (`npm ci`, the same thing CI does) and leave it alone, and a new
+  check fails the build if the file ever loses that information again.
+
+---
+
 ## 5.17.5
 
 **An update that silently does nothing is now reported as a failure, and tells you how to fix it.**

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,14 @@
 # (folded into scripts/). The 1.x C payload was already gone pre-rename.
 
 JOBS ?= $(shell getconf _NPROCESSORS_ONLN 2>/dev/null || nproc 2>/dev/null || echo 4)
-NPM_INSTALL ?= npm install --no-audit --no-fund
+# `npm ci` — NOT `npm install`. The lockfile carries `libc` fields that select
+# musl vs glibc native binaries for the Alpine-based web UI image
+# (engine/Dockerfile.webui, node:26-alpine). npm 11 writes them; npm 10 does
+# not know the field and DELETES it on every `npm install`. Since this target
+# runs on every build, an older npm silently stripped that metadata and it had
+# to be hand-reverted before each release. `npm ci` installs strictly FROM the
+# lockfile and never rewrites it, which is also what CI does.
+NPM_INSTALL ?= npm ci --no-audit --no-fund
 CARGO ?= cargo
 
 PS5_HOST ?= 192.168.137.2
@@ -648,6 +655,10 @@ test-root:
 	@node --check bench/run-ftx2-upload.mjs
 	@node --check bench/check-ftx2-baseline.mjs
 	@node --check scripts/gen-fixtures.mjs
+	@node --check scripts/check-lockfile.mjs
+	@node scripts/check-lockfile.mjs --self-test
+	@echo "Checking the client lockfile kept its libc metadata..."
+	@node scripts/check-lockfile.mjs
 	@echo "✓ Root scripts valid"
 
 test-engine: setup-engine

--- a/scripts/check-lockfile.mjs
+++ b/scripts/check-lockfile.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * Guard the client lockfile against a silent downgrade.
+ *
+ * `client/package-lock.json` carries `libc` fields on the platform-specific
+ * optional dependencies. They are not decoration: `engine/Dockerfile.webui`
+ * builds the web UI on `node:26-alpine` — musl, not glibc — and npm uses
+ * `libc` to pick the matching native binaries. npm 11 writes and honours the
+ * field; npm 10 does not know it and DELETES it from the lockfile on any
+ * `npm install`.
+ *
+ * The Makefile installs client deps on every build, so a maintainer on an
+ * older npm silently stripped that metadata every time, and it had to be
+ * hand-reverted before each release. This check fails instead, loudly, before
+ * the stripped lockfile can be committed.
+ *
+ * If this fires: do not "fix" it by committing the stripped file. Restore it
+ *   git checkout -- client/package-lock.json
+ * and use npm 11+ (Node 24+) if you need to change dependencies.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const lockPath = join(root, "client", "package-lock.json");
+
+/** Count `libc` keys in the lockfile's package entries. */
+export function countLibcEntries(lockJson) {
+  const packages = lockJson?.packages ?? {};
+  let n = 0;
+  for (const entry of Object.values(packages)) {
+    if (entry && Object.prototype.hasOwnProperty.call(entry, "libc")) n += 1;
+  }
+  return n;
+}
+
+/** Minimum expected. The committed lockfile has 6; a drop to zero is the
+ *  signature of an old npm having rewritten it. Kept as a floor rather than an
+ *  exact match so adding a dependency does not fail the build. */
+export const MIN_LIBC_ENTRIES = 1;
+
+function main() {
+  let lock;
+  try {
+    lock = JSON.parse(readFileSync(lockPath, "utf8"));
+  } catch (e) {
+    console.error(`[check-lockfile] cannot read ${lockPath}: ${e.message}`);
+    process.exit(1);
+  }
+  const n = countLibcEntries(lock);
+  if (n < MIN_LIBC_ENTRIES) {
+    console.error(
+      "[check-lockfile] client/package-lock.json has lost its `libc` fields.\n" +
+        "  These select musl vs glibc native binaries for the Alpine-based\n" +
+        "  web UI Docker build (engine/Dockerfile.webui, node:26-alpine).\n" +
+        "  An npm older than 11 deletes them on `npm install`.\n" +
+        `  Local npm: ${process.env.npm_config_user_agent ?? "unknown"}\n` +
+        "  Restore with:  git checkout -- client/package-lock.json\n" +
+        "  To change dependencies, use npm 11+ (Node 24+).",
+    );
+    process.exit(1);
+  }
+  console.log(`[check-lockfile] ok (${n} libc entries preserved)`);
+}
+
+if (process.argv[1] && process.argv[1].endsWith("check-lockfile.mjs")) {
+  if (process.argv.includes("--self-test")) {
+    const cases = [
+      [{ packages: { a: { libc: ["musl"] } } }, 1],
+      [{ packages: { a: {}, b: { libc: ["glibc"] }, c: { libc: ["musl"] } } }, 2],
+      [{ packages: { a: {}, b: {} } }, 0],
+      [{}, 0],
+      [{ packages: {} }, 0],
+    ];
+    let bad = 0;
+    for (const [input, want] of cases) {
+      const got = countLibcEntries(input);
+      if (got !== want) {
+        console.error(`FAIL: got ${got} want ${want} for ${JSON.stringify(input)}`);
+        bad += 1;
+      }
+    }
+    if (bad) process.exit(1);
+    console.log(`✓ check-lockfile self-tests passed (${cases.length})`);
+  } else {
+    main();
+  }
+}


### PR DESCRIPTION
## The churn

`make setup-client` runs `npm install`, and it runs on **every build**. npm 11 writes `libc` fields on platform-specific optional dependencies; npm 10 doesn't know the field and **deletes it**. This machine and CI (`node-version: 22`) both ship npm 10.9.8 — so every build silently rewrote `client/package-lock.json`, and it had to be hand-reverted before all five releases today.

## Why the obvious fix would have been wrong

Regenerating the lockfile without those fields looks tempting. It isn't:

`engine/Dockerfile.webui` builds the web UI on **`node:26-alpine` — musl, not glibc** — and npm uses `libc` to select matching native binaries. **Stripping them is the bug.** Had a stripped lockfile ever been committed, that image could have been built against the wrong native components. This was a latent correctness risk, not just an annoyance.

| | npm | `libc` |
|---|---|---|
| Committed lockfile | 11 | ✅ 6 entries |
| CI (`node-version: 22`) | 10.9.x | ❌ strips on `npm install` |
| **Docker webui (musl)** | 11.x | ✅ **depends on it** |

## The fix

```diff
-NPM_INSTALL ?= npm install --no-audit --no-fund
+NPM_INSTALL ?= npm ci --no-audit --no-fund
```

`npm ci` installs strictly *from* the lockfile and never rewrites it — and it's what CI already does. Verified on the very npm that caused the damage:

```
libc before: 6
make setup-client   (npm ci)
libc after:  6      no diff
```

Previously that same command stripped all six.

Plus `scripts/check-lockfile.mjs`, wired into `make test-root`, so a regression fails loudly instead of recurring silently — it reports the local npm and the restore command rather than just failing. 5 self-tests.

## Checks

`npm run validate` green, and `package-lock.json` is untouched by a full build for the first time today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnczaS2GUDN2pLkDcG2U3E